### PR TITLE
Update the way the gems context is invoked in the FlagOS Backend

### DIFF
--- a/transformer_engine/plugin/core/backends/flagos/attention/dot_product_attention/backends.py
+++ b/transformer_engine/plugin/core/backends/flagos/attention/dot_product_attention/backends.py
@@ -71,7 +71,15 @@ class AttnFuncFL(torch.autograd.Function):
 
         is_causal = attn_mask_type == 'causal'
 
-        with flag_gems.use_gems():
+        try:
+            flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
+        except Exception as e:
+            raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
+        is_flag_gems_global_enabled = flag_gems_global_registrar is not None
+        # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
+        gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
+
+        with gems_context:
             # FlagGems requires contiguous tensors, so we must call contiguous() after permute
             q_permuted = q.permute(1, 2, 0, 3).contiguous()
             k_permuted = k.permute(1, 2, 0, 3).contiguous()
@@ -160,7 +168,15 @@ class AttnFuncFL(torch.autograd.Function):
 
             dqkv_te_dtype = TE_DType[d_out.dtype]
 
-            with flag_gems.use_gems():
+            try:
+                flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
+            except Exception as e:
+                raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
+            is_flag_gems_global_enabled = flag_gems_global_registrar is not None
+            # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
+            gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
+
+            with gems_context:
                 # Ensure all tensors are contiguous for FlagGems backward
                 q_permuted = q_permuted.contiguous() if not q_permuted.is_contiguous() else q_permuted
                 k_permuted = k_permuted.contiguous() if not k_permuted.is_contiguous() else k_permuted

--- a/transformer_engine/plugin/core/backends/flagos/attention/dot_product_attention/backends.py
+++ b/transformer_engine/plugin/core/backends/flagos/attention/dot_product_attention/backends.py
@@ -35,6 +35,8 @@ from transformer_engine.plugin.core.ops import FlashAttentionBase
 
 import flag_gems
 
+from transformer_engine.plugin.core.backends.flagos.utils import gems_context
+
 class AttnFuncFL(torch.autograd.Function):
     @staticmethod
     def forward(
@@ -71,15 +73,7 @@ class AttnFuncFL(torch.autograd.Function):
 
         is_causal = attn_mask_type == 'causal'
 
-        try:
-            flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
-        except Exception as e:
-            raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
-        is_flag_gems_global_enabled = flag_gems_global_registrar is not None
-        # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
-        gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
-
-        with gems_context:
+        with gems_context():
             # FlagGems requires contiguous tensors, so we must call contiguous() after permute
             q_permuted = q.permute(1, 2, 0, 3).contiguous()
             k_permuted = k.permute(1, 2, 0, 3).contiguous()
@@ -168,15 +162,7 @@ class AttnFuncFL(torch.autograd.Function):
 
             dqkv_te_dtype = TE_DType[d_out.dtype]
 
-            try:
-                flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
-            except Exception as e:
-                raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
-            is_flag_gems_global_enabled = flag_gems_global_registrar is not None
-            # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
-            gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
-
-            with gems_context:
+            with gems_context():
                 # Ensure all tensors are contiguous for FlagGems backward
                 q_permuted = q_permuted.contiguous() if not q_permuted.is_contiguous() else q_permuted
                 k_permuted = k_permuted.contiguous() if not k_permuted.is_contiguous() else k_permuted

--- a/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
@@ -5,8 +5,7 @@
 from typing import Optional, List
 import torch
 import flag_gems
-from contextlib import nullcontext
-
+from transformer_engine.plugin.core.backends.flagos.utils import gems_context
 
 def multi_tensor_adam_fl(
     chunk_size: int,
@@ -23,15 +22,8 @@ def multi_tensor_adam_fl(
     inv_scale: Optional[float] = 1.0,
     out_dtype: Optional[torch.dtype] = None,
 ) -> None:
-    try:
-        flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
-    except Exception as e:
-        raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
-    is_flag_gems_global_enabled = flag_gems_global_registrar is not None
-    # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
-    gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
 
-    with gems_context:
+    with gems_context():
         num_lists = len(tensor_lists)
         assert num_lists in [4, 5], f"Expected 4 or 5 tensor lists, got {num_lists}"
 

--- a/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
@@ -5,6 +5,7 @@
 from typing import Optional, List
 import torch
 import flag_gems
+from contextlib import nullcontext
 
 
 def multi_tensor_adam_fl(
@@ -22,7 +23,15 @@ def multi_tensor_adam_fl(
     inv_scale: Optional[float] = 1.0,
     out_dtype: Optional[torch.dtype] = None,
 ) -> None:
-    with flag_gems.use_gems():
+    try:
+        flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
+    except Exception as e:
+        raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
+    is_flag_gems_global_enabled = flag_gems_global_registrar is not None
+    # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
+    gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
+
+    with gems_context:
         num_lists = len(tensor_lists)
         assert num_lists in [4, 5], f"Expected 4 or 5 tensor lists, got {num_lists}"
 

--- a/transformer_engine/plugin/core/backends/flagos/impl/gemm.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/gemm.py
@@ -6,8 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import torch
 
 import flag_gems
-from contextlib import nullcontext
-
+from transformer_engine.plugin.core.backends.flagos.utils import gems_context
 
 __all__ = [
     "generic_gemm_fl",
@@ -65,15 +64,8 @@ def generic_gemm_fl(
     alpha: float = 1.0,
     beta: Optional[float] = None,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
-    try:
-        flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
-    except Exception as e:
-        raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
-    is_flag_gems_global_enabled = flag_gems_global_registrar is not None
-    # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
-    gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
 
-    with gems_context:
+    with gems_context():
         assert not gelu and gelu_in is None, "Triton-Based General Gemm do not support gelu now"
         assert quantizer is None, "Triton-Based General Gemm do not support quantization now"
         assert bias is None, "Triton-Based General Gemm do not support bias now"

--- a/transformer_engine/plugin/core/backends/flagos/impl/gemm.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/gemm.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import torch
 
 import flag_gems
+from contextlib import nullcontext
+
 
 __all__ = [
     "generic_gemm_fl",
@@ -63,7 +65,15 @@ def generic_gemm_fl(
     alpha: float = 1.0,
     beta: Optional[float] = None,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
-    with flag_gems.use_gems():
+    try:
+        flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
+    except Exception as e:
+        raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
+    is_flag_gems_global_enabled = flag_gems_global_registrar is not None
+    # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
+    gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
+
+    with gems_context:
         assert not gelu and gelu_in is None, "Triton-Based General Gemm do not support gelu now"
         assert quantizer is None, "Triton-Based General Gemm do not support quantization now"
         assert bias is None, "Triton-Based General Gemm do not support bias now"

--- a/transformer_engine/plugin/core/backends/flagos/impl/multi_tensor.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/multi_tensor.py
@@ -5,20 +5,12 @@
 import torch
 from torch.distributed._tensor import DTensor
 import flag_gems
-from contextlib import nullcontext
 
-
+from transformer_engine.plugin.core.backends.flagos.utils import gems_context
 
 def multi_tensor_l2_norm_fl(chunk_size, noop_flag, tensor_lists, per_tensor, *args):
-    try:
-        flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
-    except Exception as e:
-        raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
-    is_flag_gems_global_enabled = flag_gems_global_registrar is not None
-    # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
-    gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
 
-    with gems_context:
+    with gems_context():
         tensors = tensor_lists[0]
 
         if per_tensor:
@@ -31,14 +23,7 @@ def multi_tensor_l2_norm_fl(chunk_size, noop_flag, tensor_lists, per_tensor, *ar
 
 
 def multi_tensor_scale_fl(chunk_size, noop_flag, tensor_lists, scale):
-    try:
-        flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
-    except Exception as e:
-        raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
-    is_flag_gems_global_enabled = flag_gems_global_registrar is not None
-    # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
-    gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
 
-    with gems_context:
+    with gems_context():
         for src, dst in zip(tensor_lists[0], tensor_lists[1]):
             dst.copy_(src * scale)

--- a/transformer_engine/plugin/core/backends/flagos/impl/multi_tensor.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/multi_tensor.py
@@ -5,10 +5,20 @@
 import torch
 from torch.distributed._tensor import DTensor
 import flag_gems
+from contextlib import nullcontext
+
 
 
 def multi_tensor_l2_norm_fl(chunk_size, noop_flag, tensor_lists, per_tensor, *args):
-    with flag_gems.use_gems():
+    try:
+        flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
+    except Exception as e:
+        raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
+    is_flag_gems_global_enabled = flag_gems_global_registrar is not None
+    # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
+    gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
+
+    with gems_context:
         tensors = tensor_lists[0]
 
         if per_tensor:
@@ -21,6 +31,14 @@ def multi_tensor_l2_norm_fl(chunk_size, noop_flag, tensor_lists, per_tensor, *ar
 
 
 def multi_tensor_scale_fl(chunk_size, noop_flag, tensor_lists, scale):
-    with flag_gems.use_gems():
+    try:
+        flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
+    except Exception as e:
+        raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
+    is_flag_gems_global_enabled = flag_gems_global_registrar is not None
+    # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
+    gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
+
+    with gems_context:
         for src, dst in zip(tensor_lists[0], tensor_lists[1]):
             dst.copy_(src * scale)

--- a/transformer_engine/plugin/core/backends/flagos/impl/rmsnorm.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/rmsnorm.py
@@ -4,6 +4,8 @@
 
 import torch
 import flag_gems
+from contextlib import nullcontext
+
 
 
 def rmsnorm_fwd_fl(
@@ -16,7 +18,15 @@ def rmsnorm_fwd_fl(
     sm_margin,
     zero_centered_gamma,
 ):
-    with flag_gems.use_gems():
+    try:
+        flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
+    except Exception as e:
+        raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
+    is_flag_gems_global_enabled = flag_gems_global_registrar is not None
+    # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
+    gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
+
+    with gems_context:
         if zero_centered_gamma:
             weight_adj = 1 + weight
         else:
@@ -44,7 +54,15 @@ def rmsnorm_bwd_fl(
     zero_centered_gamma,
     eps,
 ):
-    with flag_gems.use_gems():
+    try:
+        flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
+    except Exception as e:
+        raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
+    is_flag_gems_global_enabled = flag_gems_global_registrar is not None
+    # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
+    gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
+
+    with gems_context:
         # When zero_centered_gamma is True, forward uses (1 + gamma) as weight
         # So backward needs to use (1 + gamma) for computing dx
         if zero_centered_gamma:

--- a/transformer_engine/plugin/core/backends/flagos/impl/rmsnorm.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/rmsnorm.py
@@ -4,9 +4,8 @@
 
 import torch
 import flag_gems
-from contextlib import nullcontext
 
-
+from transformer_engine.plugin.core.backends.flagos.utils import gems_context
 
 def rmsnorm_fwd_fl(
     input,
@@ -18,15 +17,7 @@ def rmsnorm_fwd_fl(
     sm_margin,
     zero_centered_gamma,
 ):
-    try:
-        flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
-    except Exception as e:
-        raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
-    is_flag_gems_global_enabled = flag_gems_global_registrar is not None
-    # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
-    gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
-
-    with gems_context:
+    with gems_context():
         if zero_centered_gamma:
             weight_adj = 1 + weight
         else:
@@ -54,15 +45,7 @@ def rmsnorm_bwd_fl(
     zero_centered_gamma,
     eps,
 ):
-    try:
-        flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
-    except Exception as e:
-        raise RuntimeError(f"Failed to get flag gems registrar: {e}.")
-    is_flag_gems_global_enabled = flag_gems_global_registrar is not None
-    # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
-    gems_context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
-
-    with gems_context:
+    with gems_context():
         # When zero_centered_gamma is True, forward uses (1 + gamma) as weight
         # So backward needs to use (1 + gamma) for computing dx
         if zero_centered_gamma:

--- a/transformer_engine/plugin/core/backends/flagos/utils.py
+++ b/transformer_engine/plugin/core/backends/flagos/utils.py
@@ -1,0 +1,27 @@
+import os
+from contextlib import nullcontext
+
+
+def gems_context():
+    # check if flagos should be enabled permanently via environment variable
+    flag_gems_global_registrar = None
+    try:
+        import flag_gems
+        flag_gems_global_registrar = getattr(flag_gems, 'current_work_registrar', None)
+    except Exception as e:
+        from ...logger_manager import get_logger
+        logger = get_logger()
+        logger.warning(f"Failed to get flag gems registrar: {e}")
+        
+    is_flag_gems_global_enabled = flag_gems_global_registrar is not None
+
+    # Check if flagos should be enabled permanently via environment variable
+    enable_flagos_permanently = os.getenv("TE_FL_ENABLE_FLAGOS_PERMANENTLY", "false").lower() in ("1", "true", "yes")
+    if enable_flagos_permanently and not is_flag_gems_global_enabled:
+        flag_gems.enable(record=True, once=True)
+        is_flag_gems_global_enabled = True
+    
+    # Use nullcontext if flag_gems is already globally enabled, otherwise use use_gems() context
+    context = nullcontext() if is_flag_gems_global_enabled else flag_gems.use_gems()
+    
+    return context


### PR DESCRIPTION
Add a flag that permanently enables flag_gems with a single switch, eliminating the need to call flag_gems.use_gems for every single operator. This removes significant registration overhead and improves end-to-end throughput.
- When the flag is set, every operator’s implementation is forced to use flag_os/vendor; the default PyTorch reference backend is unavailable.
- When the flag is not set, operators can freely switch among flag_os, vendor, and torch backends.