### PR TITLE
Add multi_tensor_adam_param_remainder and context parallel support

### DIFF
--- a/transformer_engine/plugin/core/backends/fa_utils.py
+++ b/transformer_engine/plugin/core/backends/fa_utils.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2025, BAAI. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Common utilities for Flash Attention backends with Context Parallelism support."""
+
+from typing import Any, Tuple
+
+import torch
+import torch.distributed as dist
+
+
+class AllGatherFunc(torch.autograd.Function):
+    """Autograd function for all-gather along sequence dimension with proper backward."""
+
+    @staticmethod
+    def forward(ctx, input_tensor: torch.Tensor, cp_group: Any, seq_dim: int) -> torch.Tensor:
+        world_size = dist.get_world_size(cp_group)
+        gathered_list = [torch.empty_like(input_tensor) for _ in range(world_size)]
+        dist.all_gather(gathered_list, input_tensor, group=cp_group)
+        ctx.cp_group = cp_group
+        ctx.world_size = world_size
+        ctx.seq_dim = seq_dim
+        return torch.cat(gathered_list, dim=seq_dim)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> Tuple[torch.Tensor, None, None]:
+        # Split the gradient and reduce_scatter
+        grad_chunks = torch.chunk(grad_output, ctx.world_size, dim=ctx.seq_dim)
+        local_grad = torch.zeros_like(grad_chunks[0])
+        grad_list = [chunk.contiguous() for chunk in grad_chunks]
+        dist.reduce_scatter(local_grad, grad_list, group=ctx.cp_group)
+        return local_grad, None, None
+
+
+def all_gather_along_seq(
+    tensor: torch.Tensor,
+    cp_group: Any,
+    seq_dim: int = 2,
+) -> torch.Tensor:
+    """All-gather tensor along sequence dimension across CP group.
+
+    Args:
+        tensor: Input tensor to gather.
+        cp_group: Context parallelism process group.
+        seq_dim: Sequence dimension (default: 2 for BHSD format).
+
+    Returns:
+        Gathered tensor with sequence dimension scaled by CP world size.
+    """
+    world_size = dist.get_world_size(cp_group)
+    if world_size == 1:
+        return tensor
+
+    tensor = tensor.contiguous()
+    return AllGatherFunc.apply(tensor, cp_group, seq_dim)
+
+
+def reduce_scatter_along_seq(
+    tensor: torch.Tensor,
+    cp_group: Any,
+    seq_dim: int = 2,
+) -> torch.Tensor:
+    """Reduce-scatter tensor along sequence dimension across CP group.
+
+    Args:
+        tensor: Input tensor to reduce-scatter.
+        cp_group: Context parallelism process group.
+        seq_dim: Sequence dimension (default: 2 for BHSD format).
+
+    Returns:
+        Reduced tensor with sequence dimension divided by CP world size.
+    """
+    world_size = dist.get_world_size(cp_group)
+    if world_size == 1:
+        return tensor
+
+    tensor = tensor.contiguous()
+    seq_len = tensor.shape[seq_dim]
+    chunk_size = seq_len // world_size
+
+    output = torch.empty(
+        *tensor.shape[:seq_dim], chunk_size, *tensor.shape[seq_dim + 1:],
+        dtype=tensor.dtype, device=tensor.device
+    )
+
+    dist.reduce_scatter_tensor(output, tensor, group=cp_group)
+    return output
+
+
+def create_cp_causal_mask(
+    local_seq_len_q: int,
+    full_seq_len_kv: int,
+    cp_rank: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Create causal mask for context parallelism.
+
+    In CP mode, each rank processes a different chunk of the query sequence,
+    so the causal mask needs to account for global positions.
+
+    Args:
+        local_seq_len_q: Local query sequence length (per rank).
+        full_seq_len_kv: Full key/value sequence length (after all-gather).
+        cp_rank: Current rank in CP group.
+        device: Device to create mask on.
+        dtype: Data type for mask.
+
+    Returns:
+        Causal mask tensor of shape [local_seq_len_q, full_seq_len_kv].
+    """
+    # Calculate global query position offset
+    q_start = cp_rank * local_seq_len_q
+
+    # Create position indices
+    q_indices = torch.arange(local_seq_len_q, device=device, dtype=torch.long).unsqueeze(1) + q_start
+    kv_indices = torch.arange(full_seq_len_kv, device=device, dtype=torch.long).unsqueeze(0)
+
+    # Create causal mask: mask out positions where kv_idx > q_idx
+    causal_mask = torch.zeros(local_seq_len_q, full_seq_len_kv, dtype=dtype, device=device)
+    causal_mask.masked_fill_(kv_indices > q_indices, float('-inf'))
+
+    return causal_mask
+
+
+def create_cp_window_mask(
+    local_seq_len_q: int,
+    full_seq_len_kv: int,
+    cp_rank: int,
+    window_size: Tuple[int, int],
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Create sliding window mask for context parallelism.
+
+    Args:
+        local_seq_len_q: Local query sequence length (per rank).
+        full_seq_len_kv: Full key/value sequence length (after all-gather).
+        cp_rank: Current rank in CP group.
+        window_size: Tuple of (left_window, right_window). -1 means no limit.
+        device: Device to create mask on.
+        dtype: Data type for mask.
+
+    Returns:
+        Window mask tensor of shape [local_seq_len_q, full_seq_len_kv].
+    """
+    left_window, right_window = window_size
+
+    # Calculate global query position offset
+    q_start = cp_rank * local_seq_len_q
+
+    # Create position indices
+    q_indices = torch.arange(local_seq_len_q, device=device, dtype=torch.long).unsqueeze(1) + q_start
+    kv_indices = torch.arange(full_seq_len_kv, device=device, dtype=torch.long).unsqueeze(0)
+
+    # Create window mask
+    window_mask = torch.zeros(local_seq_len_q, full_seq_len_kv, dtype=dtype, device=device)
+
+    if left_window >= 0:
+        window_mask.masked_fill_(kv_indices < q_indices - left_window, float('-inf'))
+    if right_window >= 0:
+        window_mask.masked_fill_(kv_indices > q_indices + right_window, float('-inf'))
+
+    return window_mask
+
+
+def get_cp_info(cp_group: Any) -> Tuple[int, int, bool]:
+    """Get context parallelism information from process group.
+
+    Args:
+        cp_group: Context parallelism process group.
+
+    Returns:
+        Tuple of (cp_size, cp_rank, use_cp).
+    """
+    if cp_group is None:
+        return 1, 0, False
+
+    cp_size = dist.get_world_size(cp_group)
+    cp_rank = dist.get_rank(cp_group)
+    use_cp = cp_size > 1
+
+    return cp_size, cp_rank, use_cp

--- a/transformer_engine/plugin/core/backends/flagos/attention/dot_product_attention/backends.py
+++ b/transformer_engine/plugin/core/backends/flagos/attention/dot_product_attention/backends.py
@@ -9,7 +9,6 @@ import warnings
 from packaging.version import Version as PkgVersion
 
 import torch
-import torch.distributed as dist
 from transformer_engine.pytorch.utils import (
     get_device_compute_capability,
 )
@@ -33,11 +32,6 @@ from transformer_engine.pytorch.attention.inference import InferenceParams
 import transformer_engine.pytorch.attention.dot_product_attention.utils as dpa_utils
 
 from transformer_engine.plugin.core.ops import FlashAttentionBase
-from transformer_engine.plugin.core.backends.fa_utils import (
-    all_gather_along_seq,
-    create_cp_causal_mask,
-    get_cp_info,
-)
 
 import flag_gems
 
@@ -64,8 +58,6 @@ class AttnFuncFL(torch.autograd.Function):
         rng_gen,
         deterministic,
         layer_number,
-        use_cp=False,
-        cp_attn_mask=None,
     ):
         nvtx_label = "transformer_engine.AttnFuncFL.forward"
         nvtx_range_push(f"{nvtx_label}")
@@ -78,13 +70,8 @@ class AttnFuncFL(torch.autograd.Function):
 
         max_logit = None
 
-        # For CP with causal attention, use explicit mask instead of is_causal flag
-        if use_cp and cp_attn_mask is not None:
-            is_causal = False
-            attn_mask = cp_attn_mask
-        else:
-            is_causal = attn_mask_type == 'causal'
-            attn_mask = None
+        is_causal = attn_mask_type == 'causal'
+
 
         q_permuted = q.permute(1, 2, 0, 3).contiguous()
         k_permuted = k.permute(1, 2, 0, 3).contiguous()
@@ -94,7 +81,7 @@ class AttnFuncFL(torch.autograd.Function):
             q_permuted,
             k_permuted,
             v_permuted,
-            attn_mask=attn_mask,
+            attn_mask=None,
             dropout_p=dropout_p,
             is_causal=is_causal,
             scale=attn_scale,
@@ -143,8 +130,6 @@ class AttnFuncFL(torch.autograd.Function):
         ctx.attn_mask_type = attn_mask_type
         ctx.window_size = window_size
         ctx.deterministic = deterministic
-        ctx.use_cp = use_cp
-        ctx.cp_attn_mask = cp_attn_mask
 
         return out_ret
 
@@ -185,9 +170,6 @@ class AttnFuncFL(torch.autograd.Function):
             # d_out is (seq, batch, heads, dim) from autograd, permute to (batch, heads, seq, dim)
             d_out_permuted = d_out.permute(1, 2, 0, 3).contiguous()
 
-            # Use cp_attn_mask for backward if CP is enabled
-            bwd_attn_mask = ctx.cp_attn_mask if ctx.use_cp else None
-
             dq_permuted, dk_permuted, dv_permuted = flag_gems.scaled_dot_product_attention_backward(
                 d_out_permuted,
                 q_permuted,
@@ -195,7 +177,7 @@ class AttnFuncFL(torch.autograd.Function):
                 v_permuted,
                 out_permuted,
                 m,
-                attn_mask=bwd_attn_mask,
+                attn_mask=None,
                 dropout_p=ctx.dropout_p,
                 is_causal=ctx.is_causal,
                 scale=ctx.attn_scale,
@@ -209,26 +191,24 @@ class AttnFuncFL(torch.autograd.Function):
             rest = None
 
         return (
-            None,  # is_training
-            None,  # max_seqlen_q
-            None,  # max_seqlen_kv
-            None,  # cu_seqlens_q
-            None,  # cu_seqlens_kv
-            None,  # page_table_k
-            None,  # page_table_v
-            dq,    # q
-            dk,    # k
-            dv,    # v
-            None,  # attn_scale
-            None,  # dropout_p
-            None,  # qkv_layout
-            None,  # attn_mask_type
-            None,  # window_size
-            None,  # rng_gen
-            None,  # deterministic
-            None,  # layer_number
-            None,  # use_cp
-            None,  # cp_attn_mask
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            dq,
+            dk,
+            dv,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         )
 
 
@@ -309,16 +289,14 @@ class FlashAttentionFL(FlashAttentionBase):
             qkv_layout in QKVLayouts
         ), f"FLAttention does not support qkv_layout = {qkv_layout}!"
 
-        # Get CP info using shared utility
-        if isinstance(cp_group, list):
-            # Handle hierarchical CP groups
-            cp_size = 1
+        cp_size = 1
+        if isinstance(cp_group, dist_group_type):
+            cp_size = get_distributed_world_size(cp_group)
+        elif isinstance(cp_group, list):
             for group in cp_group:
                 cp_size *= get_distributed_world_size(group)
-            cp_rank = 0  # Need proper handling for hierarchical groups
-            use_cp = cp_size > 1
-        else:
-            cp_size, cp_rank, use_cp = get_cp_info(cp_group)
+        context_parallel = cp_size > 1
+        assert not context_parallel, "FLAttention do not support context parallel now"
 
         qkv_format, q_format, kv_format = dpa_utils.get_qkv_format(qkv_layout, inference_params)
 
@@ -344,7 +322,7 @@ class FlashAttentionFL(FlashAttentionBase):
                 max_seqlen_kv *= cp_size
                 if "padding" in attn_mask_type:
                     assert (
-                        not use_cp
+                        not context_parallel
                     ), "Padding mask not supported with context parallelism!"
                     if cu_seqlens_q is None or cu_seqlens_kv is None:
                         if attention_mask is None:
@@ -380,43 +358,6 @@ class FlashAttentionFL(FlashAttentionBase):
         elif inference_params.is_paged:
             page_table = inference_params.cache_manager.page_table
 
-        # Context Parallelism support: all-gather key/value and create causal mask
-        cp_attn_mask = None
-        local_seq_len_q = query_layer.shape[0] if qkv_format == "sbhd" else query_layer.shape[1]
-
-        if use_cp:
-            # Convert to BHSD format for all-gather (seq_dim=2)
-            if qkv_format == "sbhd":
-                # sbhd -> bhsd: [seq, batch, heads, dim] -> [batch, heads, seq, dim]
-                key_bhsd = key_layer.permute(1, 2, 0, 3).contiguous()
-                value_bhsd = value_layer.permute(1, 2, 0, 3).contiguous()
-            else:  # bshd
-                # bshd -> bhsd: [batch, seq, heads, dim] -> [batch, heads, seq, dim]
-                key_bhsd = key_layer.permute(0, 2, 1, 3).contiguous()
-                value_bhsd = value_layer.permute(0, 2, 1, 3).contiguous()
-
-            # All-gather key/value along sequence dimension
-            key_bhsd = all_gather_along_seq(key_bhsd, cp_group, seq_dim=2)
-            value_bhsd = all_gather_along_seq(value_bhsd, cp_group, seq_dim=2)
-
-            # Convert back to original format
-            if qkv_format == "sbhd":
-                # bhsd -> sbhd
-                key_layer = key_bhsd.permute(2, 0, 1, 3).contiguous()
-                value_layer = value_bhsd.permute(2, 0, 1, 3).contiguous()
-            else:  # bshd
-                # bhsd -> bshd
-                key_layer = key_bhsd.permute(0, 2, 1, 3).contiguous()
-                value_layer = value_bhsd.permute(0, 2, 1, 3).contiguous()
-
-            # Create CP causal mask if causal attention
-            if attn_mask_type == "causal":
-                full_seq_len_kv = key_layer.shape[0] if qkv_format == "sbhd" else key_layer.shape[1]
-                cp_attn_mask = create_cp_causal_mask(
-                    local_seq_len_q, full_seq_len_kv, cp_rank,
-                    query_layer.device, query_layer.dtype
-                )
-
         with self.attention_dropout_ctx():
             _attn_impl = AttnFuncFL
             output = _attn_impl.apply(
@@ -438,8 +379,6 @@ class FlashAttentionFL(FlashAttentionBase):
                 None,
                 self.deterministic,
                 self.layer_number,
-                use_cp,
-                cp_attn_mask,
             )
 
         return output.view(*output.shape[:-2], -1)

--- a/transformer_engine/plugin/core/backends/flagos/flagos.py
+++ b/transformer_engine/plugin/core/backends/flagos/flagos.py
@@ -12,6 +12,7 @@ from ...ops import TEFLBackendBase, FP8TensorMeta, NVTE_Fused_Attn_Backend
 from .impl import (
     rmsnorm_fwd_fl, rmsnorm_bwd_fl,
     multi_tensor_scale_fl, multi_tensor_adam_fl,
+    multi_tensor_adam_param_remainder_fl,
     multi_tensor_l2_norm_fl,
     generic_gemm_fl
 )
@@ -166,6 +167,28 @@ class FlagOSBackend(TEFLBackendBase):
         if chunk_size is None:
             return multi_tensor_adam_fl
         return multi_tensor_adam_fl(
+            chunk_size=chunk_size, noop_flag=noop_flag, tensor_lists=tensor_lists,
+            lr=lr, beta1=beta1, beta2=beta2, eps=eps,
+            step=step, mode=mode, bias_correction=bias_correction, weight_decay=weight_decay,
+        )
+
+    def multi_tensor_adam_param_remainder(
+        self,
+        chunk_size: int = None,
+        noop_flag: torch.Tensor = None,
+        tensor_lists: List[List[torch.Tensor]] = None,
+        lr: float = None,
+        beta1: float = None,
+        beta2: float = None,
+        eps: float = None,
+        step: int = None,
+        mode: int = None,
+        bias_correction: int = None,
+        weight_decay: float = None,
+    ):
+        if chunk_size is None:
+            return multi_tensor_adam_param_remainder_fl
+        return multi_tensor_adam_param_remainder_fl(
             chunk_size=chunk_size, noop_flag=noop_flag, tensor_lists=tensor_lists,
             lr=lr, beta1=beta1, beta2=beta2, eps=eps,
             step=step, mode=mode, bias_correction=bias_correction, weight_decay=weight_decay,

--- a/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
@@ -75,3 +75,116 @@ def multi_tensor_adam_fl(
             flag_gems.copy_(p_master, p)
             out_dtype = p_master.dtype if out_dtype is None else out_dtype
             p.data = p.data.to(out_dtype)
+
+
+def multi_tensor_adam_param_remainder_fl(
+    chunk_size: int,
+    noop_flag: torch.Tensor,
+    tensor_lists: List[List[torch.Tensor]],
+    lr: float,
+    beta1: float,
+    beta2: float,
+    eps: float,
+    step: int,
+    mode: int,
+    bias_correction: int,
+    weight_decay: float,
+    inv_scale: Optional[float] = 1.0,
+) -> None:
+    """
+    Adam optimizer with parameter remainders for BF16 precision (FlagOS implementation).
+
+    This variant stores BF16 parameters + int16 remainders to reconstruct FP32 master weights.
+    Used when you have BF16 params and need FP32 master params without storing full FP32 copies.
+
+    Args:
+        chunk_size: Chunk size for processing (unused in this implementation)
+        noop_flag: If non-zero, skip computation
+        tensor_lists: [grads, params (bf16), exp_avgs (fp32), exp_avg_sqs (fp32), param_remainders (int16)]
+        lr: Learning rate
+        beta1: First moment decay rate
+        beta2: Second moment decay rate
+        eps: Epsilon for numerical stability
+        step: Current optimization step
+        mode: 0 = L2 regularization, 1 = AdamW (decoupled weight decay)
+        bias_correction: Whether to apply bias correction (1 = yes, 0 = no)
+        weight_decay: Weight decay coefficient
+        inv_scale: Inverse gradient scale for mixed precision training
+    """
+    if noop_flag.item() != 0:
+        return
+
+    num_lists = len(tensor_lists)
+    assert num_lists == 5, f"Expected 5 tensor lists, got {num_lists}"
+
+    num_tensors = len(tensor_lists[0])
+    assert num_tensors > 0, "No tensors provided"
+
+    for i, lst in enumerate(tensor_lists):
+        assert len(lst) == num_tensors, f"List {i} has {len(lst)} tensors, expected {num_tensors}"
+
+    bias_correction1 = 1.0
+    bias_correction2 = 1.0
+    if bias_correction == 1:
+        bias_correction1 = 1 - beta1 ** step
+        bias_correction2 = 1 - beta2 ** step
+
+    is_adamw = (mode == 1)
+
+    for i in range(num_tensors):
+        g = tensor_lists[0][i]
+        p = tensor_lists[1][i]  # BF16 parameter
+        m = tensor_lists[2][i]  # FP32 first moment
+        v = tensor_lists[3][i]  # FP32 second moment
+        p_remainder = tensor_lists[4][i]  # int16 remainder
+
+        if not g.is_contiguous():
+            g = g.contiguous()
+
+        # Apply gradient unscaling if needed
+        if inv_scale is not None and inv_scale != 1.0:
+            g = flag_gems.mul(g, inv_scale)
+
+        # Reconstruct FP32 master weight from BF16 param + int16 remainder
+        # The remainder represents the lower 16 bits lost in BF16 conversion
+        param_fp32 = p.float()
+        param_master = flag_gems.add(param_fp32, flag_gems.mul(p_remainder.float(), 2.0 ** -16))
+
+        # Compute gradient with weight decay (if L2 mode)
+        grad_with_decay = g.float()
+        if not is_adamw:  # L2 regularization mode
+            grad_with_decay = flag_gems.add(grad_with_decay, flag_gems.mul(param_master, weight_decay))
+
+        # Update moments
+        m = flag_gems.add_(flag_gems.mul_(m, beta1), grad_with_decay, alpha=1 - beta1)
+        v = flag_gems.add_(flag_gems.mul_(v, beta2), flag_gems.mul_(flag_gems.mul_(grad_with_decay, grad_with_decay), 1 - beta2))
+
+        # Apply bias correction
+        m_corr = m.clone()
+        v_corr = v.clone()
+        if bias_correction == 1:
+            m_corr = flag_gems.true_divide(m_corr, bias_correction1)
+            v_corr = flag_gems.true_divide(v_corr, bias_correction2)
+
+        # Compute update
+        update = flag_gems.true_divide(m_corr, flag_gems.add(flag_gems.sqrt(v_corr), eps))
+
+        # Apply weight decay (if AdamW mode)
+        if is_adamw:
+            param_master = flag_gems.mul_(param_master, 1 - lr * weight_decay)
+
+        # Update master weight
+        param_master = flag_gems.add_(param_master, update, alpha=-lr)
+
+        # Split back into BF16 param + int16 remainder
+        # Convert to BF16 (this is the rounded version)
+        param_bf16 = param_master.to(dtype=p.dtype)
+
+        # Compute remainder: difference between FP32 master and BF16 representation
+        # Scale and quantize to int16 range
+        remainder_fp32 = flag_gems.mul(flag_gems.sub(param_master, param_bf16.float()), 2.0 ** 16)
+        remainder_int16 = flag_gems.clamp(flag_gems.round(remainder_fp32), -32768, 32767).to(dtype=torch.int16)
+
+        # Write back
+        flag_gems.copy_(p, param_bf16)
+        flag_gems.copy_(p_remainder, remainder_int16)

--- a/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
@@ -183,7 +183,7 @@ def multi_tensor_adam_param_remainder_fl(
         # Compute remainder: difference between FP32 master and BF16 representation
         # Scale and quantize to int16 range
         remainder_fp32 = flag_gems.mul(flag_gems.sub(param_master, param_bf16.float()), 2.0 ** 16)
-        remainder_int16 = flag_gems.clamp(flag_gems.round(remainder_fp32), -32768, 32767).to(dtype=torch.int16)
+        remainder_int16 = flag_gems.clamp(torch.round(remainder_fp32), -32768, 32767).to(dtype=torch.int16)
 
         # Write back
         flag_gems.copy_(p, param_bf16)

--- a/transformer_engine/plugin/core/backends/flagos/register_ops.py
+++ b/transformer_engine/plugin/core/backends/flagos/register_ops.py
@@ -45,6 +45,7 @@ def register_builtins(registry) -> None:
         OpImpl(op_name="generic_gemm", impl_id="default.flagos", kind=BackendImplKind.DEFAULT, fn=_bind_is_available(backend.generic_gemm, is_avail), vendor=None, priority=150),
         OpImpl(op_name="multi_tensor_scale", impl_id="default.flagos", kind=BackendImplKind.DEFAULT, fn=_bind_is_available(backend.multi_tensor_scale, is_avail), vendor=None, priority=150),
         OpImpl(op_name="multi_tensor_adam", impl_id="default.flagos", kind=BackendImplKind.DEFAULT, fn=_bind_is_available(backend.multi_tensor_adam, is_avail), vendor=None, priority=150),
+        OpImpl(op_name="multi_tensor_adam_param_remainder", impl_id="default.flagos", kind=BackendImplKind.DEFAULT, fn=_bind_is_available(backend.multi_tensor_adam_param_remainder, is_avail), vendor=None, priority=150),
         OpImpl(op_name="multi_tensor_l2norm", impl_id="default.flagos", kind=BackendImplKind.DEFAULT, fn=_bind_is_available(backend.multi_tensor_l2norm, is_avail), vendor=None, priority=150),
 
         # FlashAttention class getter

--- a/transformer_engine/plugin/core/backends/reference/impl/__init__.py
+++ b/transformer_engine/plugin/core/backends/reference/impl/__init__.py
@@ -35,6 +35,7 @@ from .optimizer import (
     multi_tensor_scale_torch,
     multi_tensor_l2norm_torch,
     multi_tensor_adam_torch,
+    multi_tensor_adam_param_remainder_torch,
     multi_tensor_sgd_torch,
     multi_tensor_compute_scale_and_scale_inv_torch,
 )
@@ -85,6 +86,7 @@ __all__ = [
     "multi_tensor_scale_torch",
     "multi_tensor_l2norm_torch",
     "multi_tensor_adam_torch",
+    "multi_tensor_adam_param_remainder_torch",
     "multi_tensor_sgd_torch",
     "multi_tensor_compute_scale_and_scale_inv_torch",
 ]

--- a/transformer_engine/plugin/core/backends/reference/reference.py
+++ b/transformer_engine/plugin/core/backends/reference/reference.py
@@ -29,7 +29,8 @@ from .impl import (
     scaled_aligned_causal_masked_softmax_backward_torch,
     dropout_fwd_torch, dropout_bwd_torch,
     multi_tensor_scale_torch, multi_tensor_l2norm_torch,
-    multi_tensor_adam_torch, multi_tensor_sgd_torch,
+    multi_tensor_adam_torch, multi_tensor_adam_param_remainder_torch,
+    multi_tensor_sgd_torch,
 )
 
 class ReferenceBackend(TEFLBackendBase):
@@ -506,8 +507,10 @@ class ReferenceBackend(TEFLBackendBase):
             return multi_tensor_adam_torch
         return multi_tensor_adam_torch(*args, **kwargs)
 
-    def multi_tensor_adam_param_remainder(self, *args, **kwargs) -> None:
-        raise NotImplementedError("multi_tensor_adam_param_remainder - not implemented in reference backend")
+    def multi_tensor_adam_param_remainder(self, *args, **kwargs):
+        if not args and not kwargs:
+            return multi_tensor_adam_param_remainder_torch
+        return multi_tensor_adam_param_remainder_torch(*args, **kwargs)
 
     def multi_tensor_adam_fp8(self, *args, **kwargs) -> None:
         raise NotImplementedError("multi_tensor_adam_fp8 - not implemented in reference backend")

--- a/transformer_engine/plugin/core/backends/vendor/hygon/flash_attention.py
+++ b/transformer_engine/plugin/core/backends/vendor/hygon/flash_attention.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2025, BAAI. All rights reserved.
+#
+# See LICENSE for license information.
+
+from contextlib import nullcontext
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import torch
+
+from transformer_engine.plugin.core.ops import FlashAttentionBase
+
+class FlashAttentionHYGON(FlashAttentionBase):
+    def __init__(
+        self,
+        softmax_scale: float,
+        attention_dropout: float = 0.0,
+        attention_dropout_ctx: Optional[Callable] = None,
+        attention_type: str = "self",
+        layer_number: Optional[int] = None,
+        deterministic: bool = False,
+    ) -> None:
+        super().__init__(
+            softmax_scale=softmax_scale,
+            attention_dropout=attention_dropout,
+            attention_dropout_ctx=attention_dropout_ctx,
+            attention_type=attention_type,
+            layer_number=layer_number,
+            deterministic=deterministic,
+        )
+
+        # Store initialization parameters for lazy loading
+        self._init_params = {
+            'softmax_scale': softmax_scale,
+            'attention_dropout': attention_dropout,
+            'attention_dropout_ctx': attention_dropout_ctx or nullcontext,
+            'attention_type': attention_type,
+            'layer_number': layer_number,
+            'deterministic': deterministic,
+        }
+        self._native_flash_attn = None
+
+    def _ensure_native_flash_attn(self):
+        """Lazy initialization of native FlashAttention."""
+        if self._native_flash_attn is not None:
+            return
+
+        try:
+            # Import here to avoid circular dependency issues
+            # transformer_engine_torch must be registered before this import
+            from transformer_engine.pytorch.attention.dot_product_attention.backends import (
+                FlashAttention as FlashAttentionNative,
+            )
+
+            if FlashAttentionNative is None:
+                raise RuntimeError("FlashAttention class is None - flash-attn may not be installed correctly")
+
+            self._native_flash_attn = FlashAttentionNative(**self._init_params)
+
+        except ImportError as e:
+            raise RuntimeError(
+                f"Failed to import native FlashAttention: {e}. "
+                "Please ensure flash-attn is installed and transformer_engine_torch is available."
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to initialize native FlashAttention: {e}. "
+                f"Init params: {self._init_params}"
+            )
+
+    @property
+    def backend_name(self) -> str:
+        return "hygon"
+
+    def _forward_impl(
+        self,
+        query_layer: torch.Tensor,
+        key_layer: torch.Tensor,
+        value_layer: torch.Tensor,
+        attention_mask: Optional[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]] = None,
+        qkv_layout: str = "sbh3d",
+        cu_seqlens_q: Optional[torch.Tensor] = None,
+        cu_seqlens_kv: Optional[torch.Tensor] = None,
+        max_seqlen_q: Optional[int] = None,
+        max_seqlen_kv: Optional[int] = None,
+        attn_mask_type: str = "causal",
+        window_size: Optional[Tuple[int, int]] = None,
+        alibi_slopes: Optional[torch.Tensor] = None,
+        cp_group: Optional[Any] = None,
+        cp_global_ranks: Optional[List[int]] = None,
+        cp_stream: Optional[torch.cuda.Stream] = None,
+        cp_comm_type: str = "p2p",
+        fp8: bool = False,
+        fp8_meta: Optional[Dict[str, Any]] = None,
+        quantizers: Optional[Any] = None,
+        inference_params: Optional[Any] = None,
+        flash_attention_backend: Optional[Any] = None,
+        fp8_output: bool = False,
+    ) -> torch.Tensor:
+        # Ensure native flash attention is initialized
+        self._ensure_native_flash_attn()
+
+        return self._native_flash_attn(
+            query_layer=query_layer,
+            key_layer=key_layer,
+            value_layer=value_layer,
+            attention_mask=attention_mask,
+            qkv_layout=qkv_layout,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_kv=cu_seqlens_kv,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_kv=max_seqlen_kv,
+            attn_mask_type=attn_mask_type,
+            window_size=window_size,
+            alibi_slopes=alibi_slopes,
+            cp_group=cp_group,
+            cp_global_ranks=cp_global_ranks,
+            cp_stream=cp_stream,
+            cp_comm_type=cp_comm_type,
+            fp8=fp8,
+            fp8_meta=fp8_meta,
+            quantizers=quantizers,
+            inference_params=inference_params,
+            flash_attention_backend=flash_attention_backend,
+            fp8_output=fp8_output,
+        )

--- a/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
+++ b/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
@@ -2,19 +2,19 @@
 #
 # See LICENSE for license information.
 
+import os
+import sys
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
-import sys
 
-from ....ops import TEFLBackendBase, FP8TensorMeta
+from ....ops import TEFLBackendBase, FP8TensorMeta, NVTE_Fused_Attn_Backend
 
 def _load_hygon_libs():
     import ctypes
     from pathlib import Path
     import importlib
     import platform
-    import os
     common_prefix = "libtransformer_engine"
     csrc_prefix = "transformer_engine_torch_hygon"
     common_files = []
@@ -165,7 +165,36 @@ class HygonBackend(TEFLBackendBase):
         return FlashAttentionHYGON
 
     def get_attention_backend(self, attention_params=None):
-        raise NotImplementedError("get_attention_backend - not implemented in hygon backend")
+        from packaging.version import Version as PkgVersion
+        from ....logger_manager import get_logger
+        logger = get_logger()
+
+        # Read environment variables to determine which backends to enable
+        use_flash_attention = int(os.getenv("NVTE_FLASH_ATTN", "1"))
+        use_fused_attention = int(os.getenv("NVTE_FUSED_ATTN", "1"))
+        use_unfused_attention = int(os.getenv("NVTE_UNFUSED_ATTN", "1"))
+
+        # Log disabled backends
+        if not use_flash_attention:
+            logger.info_once("Disabling FlashAttention due to NVTE_FLASH_ATTN=0")
+        if not use_fused_attention:
+            logger.info_once("Disabling FusedAttention due to NVTE_FUSED_ATTN=0")
+        if not use_unfused_attention:
+            logger.info_once("Disabling UnfusedDotProductAttention due to NVTE_UNFUSED_ATTN=0")
+
+        flash_attention_backend = PkgVersion("2.6.0") if use_flash_attention else None
+        fused_attention_backend = NVTE_Fused_Attn_Backend.NVTE_No_Backend
+
+        available_backends = [use_flash_attention, use_fused_attention, use_unfused_attention]
+
+        return (
+            use_flash_attention,
+            flash_attention_backend,
+            use_fused_attention,
+            fused_attention_backend,
+            use_unfused_attention,
+            available_backends,
+        )
 
     def quantize(
         self,

--- a/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
+++ b/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
@@ -161,7 +161,8 @@ class HygonBackend(TEFLBackendBase):
         return _check_hygon_available()
 
     def get_flash_attention_class(self):
-        raise NotImplementedError("get_flash_attention_class - not implemented in hygon backend")
+        from .flash_attention import FlashAttentionHYGON
+        return FlashAttentionHYGON
 
     def get_attention_backend(self, attention_params=None):
         raise NotImplementedError("get_attention_backend - not implemented in hygon backend")

--- a/transformer_engine/plugin/core/backends/vendor/hygon/register_ops.py
+++ b/transformer_engine/plugin/core/backends/vendor/hygon/register_ops.py
@@ -112,6 +112,8 @@ def register_builtins(registry) -> None:
         OpImpl(op_name="moe_unpermute_bwd", impl_id="vendor.hygon", kind=BackendImplKind.VENDOR, fn=_bind_is_available(backend.moe_unpermute_bwd, is_avail), vendor="HYGON", priority=100),
 
         # Fused attention
+        OpImpl(op_name="fa_prepare_fwd", impl_id="vendor.hygon", kind=BackendImplKind.VENDOR, fn=_bind_is_available(backend.fa_prepare_fwd, is_avail), vendor="HYGON", priority=100),
+        OpImpl(op_name="fa_prepare_bwd", impl_id="vendor.hygon", kind=BackendImplKind.VENDOR, fn=_bind_is_available(backend.fa_prepare_bwd, is_avail), vendor="HYGON", priority=100),
 
         # KV cache
         OpImpl(op_name="copy_to_kv_cache", impl_id="vendor.hygon", kind=BackendImplKind.VENDOR, fn=_bind_is_available(backend.copy_to_kv_cache, is_avail), vendor="HYGON", priority=100),
@@ -188,6 +190,8 @@ def register_builtins(registry) -> None:
         # FlashAttention class getter
         OpImpl(op_name="get_flash_attention_class", impl_id="vendor.hygon", kind=BackendImplKind.VENDOR, fn=_bind_is_available(backend.get_flash_attention_class, is_avail), vendor="HYGON", priority=100),
 
+        # Attention backend selection
+        OpImpl(op_name="get_attention_backend", impl_id="vendor.hygon", kind=BackendImplKind.VENDOR, fn=_bind_is_available(backend.get_attention_backend, is_avail), vendor="HYGON", priority=100),
     ]
 
     registry.register_many(impls)

--- a/transformer_engine/plugin/core/backends/vendor/hygon/register_ops.py
+++ b/transformer_engine/plugin/core/backends/vendor/hygon/register_ops.py
@@ -186,6 +186,8 @@ def register_builtins(registry) -> None:
         OpImpl(op_name="create_comm_overlap_p2p", impl_id="vendor.hygon", kind=BackendImplKind.VENDOR, fn=_bind_is_available(backend.create_comm_overlap_p2p, is_avail), vendor="HYGON", priority=100),
 
         # FlashAttention class getter
+        OpImpl(op_name="get_flash_attention_class", impl_id="vendor.hygon", kind=BackendImplKind.VENDOR, fn=_bind_is_available(backend.get_flash_attention_class, is_avail), vendor="HYGON", priority=100),
+
     ]
 
     registry.register_many(impls)

--- a/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
+++ b/transformer_engine/pytorch/attention/dot_product_attention/context_parallel.py
@@ -1008,6 +1008,9 @@ def cp_p2p_bwd_flash_attn(
     dq, dk, dv = [torch.empty_like(x) for x in [q_part, k_part, v_part]]
     if use_flash_attn_3 or (fa_utils.v2_3_plus and not fa_utils.v2_7_0_plus):
         fa_backward_kwargs["window_size"] = (-1, -1)
+        # Fix: flash-attn 2.3.x ~ 2.6.x also needs rng_state for dropout
+        if not use_flash_attn_3 and rng_states is not None:
+            fa_backward_kwargs["rng_state"] = rng_states[cp_size - step - 1]
     elif fa_utils.v2_7_0_plus:
         fa_backward_kwargs["window_size_left"] = -1
         fa_backward_kwargs["window_size_right"] = -1


### PR DESCRIPTION
## Summary
- flagos: Add multi_tensor_adam_param_remainder implementation
- reference: Add multi_tensor_adam_param_remainder implementation  
- reference: Add context parallel support for Flash Attention
- manager: Add cache mechanism with _impl_cache and _impl_cache_meta for conditional op selection

## Changes
### flagos backend
- Implemented multi_tensor_adam_param_remainder operation for handling parameter remainders in multi-tensor Adam optimizer

### reference backend  
- Implemented multi_tensor_adam_param_remainder operation
- Added context parallel support for Flash Attention implementation

### Core manager
- Added cache mechanism using _impl_cache and _impl_cache_meta
- Improved op selection with conditional caching based on policy fingerprint and epoch