### PR TITLE
Fix: Resolve parameter mismatch between TE_FL and NVTE functions

### DIFF
--- a/transformer_engine/plugin/core/backends/flagos/flagos.py
+++ b/transformer_engine/plugin/core/backends/flagos/flagos.py
@@ -163,7 +163,7 @@ class FlagOSBackend(TEFLBackendBase):
             return multi_tensor_adam_fl
         return multi_tensor_adam_fl(
             chunk_size=chunk_size, noop_flag=noop_flag, tensor_lists=tensor_lists,
-            lr=lr, beta1=beta1, beta2=beta2, eps=epsilon,
+            lr=lr, beta1=beta1, beta2=beta2, epsilon=epsilon,
             step=step, mode=mode, bias_correction=bias_correction, weight_decay=weight_decay,
         )
     def multi_tensor_adam_param_remainder(
@@ -184,7 +184,7 @@ class FlagOSBackend(TEFLBackendBase):
             return multi_tensor_adam_param_remainder_fl
         return multi_tensor_adam_param_remainder_fl(
             chunk_size=chunk_size, noop_flag=noop_flag, tensor_lists=tensor_lists,
-            lr=lr, beta1=beta1, beta2=beta2, eps=epsilon,
+            lr=lr, beta1=beta1, beta2=beta2, epsilon=epsilon,
             step=step, mode=mode, bias_correction=bias_correction, weight_decay=weight_decay,
         )
 

--- a/transformer_engine/plugin/core/backends/flagos/flagos.py
+++ b/transformer_engine/plugin/core/backends/flagos/flagos.py
@@ -159,12 +159,9 @@ class FlagOSBackend(TEFLBackendBase):
         bias_correction: int,
         weight_decay: float,
     ) -> None:
-        if chunk_size is None:
-            return multi_tensor_adam_fl
         return multi_tensor_adam_fl(
-            chunk_size=chunk_size, noop_flag=noop_flag, tensor_lists=tensor_lists,
-            lr=lr, beta1=beta1, beta2=beta2, epsilon=epsilon,
-            step=step, mode=mode, bias_correction=bias_correction, weight_decay=weight_decay,
+            chunk_size, noop_flag, tensor_lists, lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
         )
     def multi_tensor_adam_param_remainder(
         self,
@@ -180,12 +177,10 @@ class FlagOSBackend(TEFLBackendBase):
         bias_correction: int,
         weight_decay: float,
     ) -> None:
-        if chunk_size is None:
-            return multi_tensor_adam_param_remainder_fl
         return multi_tensor_adam_param_remainder_fl(
-            chunk_size=chunk_size, noop_flag=noop_flag, tensor_lists=tensor_lists,
-            lr=lr, beta1=beta1, beta2=beta2, epsilon=epsilon,
-            step=step, mode=mode, bias_correction=bias_correction, weight_decay=weight_decay,
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
         )
 
     # Misc

--- a/transformer_engine/plugin/core/backends/flagos/flagos.py
+++ b/transformer_engine/plugin/core/backends/flagos/flagos.py
@@ -64,19 +64,19 @@ class FlagOSBackend(TEFLBackendBase):
     def generic_gemm(
         self,
         A: Any,
-        transa: bool,
+        transA: bool,
         B: Any,
-        transb: bool,
+        transB: bool,
         D: Any,
         quantizer: Any,
-        out_dtype: Optional[DType],
+        output_dtype: Optional[DType],
         bias: Optional[torch.Tensor],
         bias_type: DType,
         gelu: bool,
         gelu_in: Optional[torch.Tensor],
         grad: bool,
         workspace: torch.Tensor,
-        workspaceSize: int,
+        workspace_size: int,
         accumulate: bool,
         use_split_accumulator: bool,
         comm_overlap: Optional[Any] = None,
@@ -87,26 +87,24 @@ class FlagOSBackend(TEFLBackendBase):
         beta: Optional[float] = None,
     ) -> List[Any]:
         return generic_gemm_fl(
-            A, transa, B, transb, D, quantizer, out_dtype,
-            bias, bias_type, gelu, gelu_in, grad,
-            workspace, workspaceSize, accumulate, use_split_accumulator,
-            comm_overlap=comm_overlap, comm_type=comm_type,
-            extra_output=extra_output, bulk_overlap=bulk_overlap,
-            alpha=alpha, beta=beta
+            A, transA, B, transB, D, quantizer, output_dtype,
+            bias, bias_type, gelu, gelu_in, grad, workspace, workspace_size,
+            accumulate, use_split_accumulator, comm_overlap, comm_type,
+            extra_output, bulk_overlap, alpha, beta
         )
 
     # Other granular functions
     def rmsnorm_fwd(
         self,
-        input: torch.Tensor,
-        weight: torch.Tensor,
+        input: Any,
+        weight: Any,
         eps: float,
-        ln_out: Optional[torch.Tensor],
+        ln_out: Any,
         quantizer: Any,
         otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    ) -> List[Any]:
         return rmsnorm_fwd_fl(
             input=input, weight=weight, eps=eps, ln_out=ln_out,
             quantizer=quantizer, odtype=otype,
@@ -118,9 +116,9 @@ class FlagOSBackend(TEFLBackendBase):
         x: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         return rmsnorm_bwd_fl(
             dy=dz, x=x, rsigma=rsigma, gamma=gamma,
             sm_margin=sm_margin, zero_centered_gamma=zero_centered_gamma

--- a/transformer_engine/plugin/core/backends/flagos/flagos.py
+++ b/transformer_engine/plugin/core/backends/flagos/flagos.py
@@ -7,7 +7,7 @@ from typing import Any, List, Optional, Tuple, Union
 
 import torch
 
-from ...ops import TEFLBackendBase, FP8TensorMeta, NVTE_Fused_Attn_Backend
+from ...ops import *
 
 from .impl import (
     rmsnorm_fwd_fl, rmsnorm_bwd_fl,
@@ -20,7 +20,6 @@ from .impl import (
 def _check_flagos_available() -> bool:
     return True
 
-
 class FlagOSBackend(TEFLBackendBase):
     @staticmethod
     def check_available() -> bool:
@@ -28,10 +27,6 @@ class FlagOSBackend(TEFLBackendBase):
 
     def is_available(self) -> bool:
         return _check_flagos_available()
-
-    def get_flash_attention_class(self):
-        from .attention.dot_product_attention.backends import FlashAttentionFL
-        return FlashAttentionFL
 
     def get_attention_backend(self, attention_params=None):
         from packaging.version import Version as PkgVersion
@@ -65,40 +60,42 @@ class FlagOSBackend(TEFLBackendBase):
             available_backends,
         )
 
+##### transformer_engine/pytorch/csrc/extensions/pybind.cpp #####
     def generic_gemm(
         self,
-        A: torch.Tensor,
-        transA: bool,
-        B: torch.Tensor,
-        transB: bool,
-        D: torch.Tensor,
+        A: Any,
+        transa: bool,
+        B: Any,
+        transb: bool,
+        D: Any,
         quantizer: Any,
-        output_dtype: torch.dtype,
+        out_dtype: Optional[DType],
         bias: Optional[torch.Tensor],
-        bias_type: Any,
+        bias_type: DType,
         gelu: bool,
         gelu_in: Optional[torch.Tensor],
         grad: bool,
         workspace: torch.Tensor,
-        workspace_size: int,
+        workspaceSize: int,
         accumulate: bool,
         use_split_accumulator: bool,
         comm_overlap: Optional[Any] = None,
-        comm_type: Optional[Any] = None,
+        comm_type: Optional[CommOverlapType] = None,
         extra_output: Optional[torch.Tensor] = None,
         bulk_overlap: bool = False,
         alpha: float = 1.0,
         beta: Optional[float] = None,
-    ) -> Any:
+    ) -> List[Any]:
         return generic_gemm_fl(
-            A, transA, B, transB, D, quantizer, output_dtype,
+            A, transa, B, transb, D, quantizer, out_dtype,
             bias, bias_type, gelu, gelu_in, grad,
-            workspace, workspace_size, accumulate, use_split_accumulator,
+            workspace, workspaceSize, accumulate, use_split_accumulator,
             comm_overlap=comm_overlap, comm_type=comm_type,
             extra_output=extra_output, bulk_overlap=bulk_overlap,
             alpha=alpha, beta=beta
         )
 
+    # Other granular functions
     def rmsnorm_fwd(
         self,
         input: torch.Tensor,
@@ -106,7 +103,7 @@ class FlagOSBackend(TEFLBackendBase):
         eps: float,
         ln_out: Optional[torch.Tensor],
         quantizer: Any,
-        otype: torch.dtype,
+        otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
@@ -115,22 +112,23 @@ class FlagOSBackend(TEFLBackendBase):
             quantizer=quantizer, odtype=otype,
             sm_margin=sm_margin, zero_centered_gamma=zero_centered_gamma,
         )
-
     def rmsnorm_bwd(
         self,
-        dy: torch.Tensor,
+        dz: torch.Tensor,
         x: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
         sm_margin: int = 0,
         zero_centered_gamma: bool = False,
-        eps: float = 1e-5,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         return rmsnorm_bwd_fl(
-            dy=dy, x=x, rsigma=rsigma, gamma=gamma,
-            sm_margin=sm_margin, zero_centered_gamma=zero_centered_gamma, eps=eps,
+            dy=dz, x=x, rsigma=rsigma, gamma=gamma,
+            sm_margin=sm_margin, zero_centered_gamma=zero_centered_gamma
         )
+    def get_fused_attn_backend(self, *args, **kwargs) -> int:
+        return NVTE_Fused_Attn_Backend.NVTE_No_Backend
 
+    # multi-tensor functions
     def multi_tensor_scale(
         self,
         chunk_size: int,
@@ -139,73 +137,66 @@ class FlagOSBackend(TEFLBackendBase):
         scale: float,
     ) -> None:
         return multi_tensor_scale_fl(chunk_size, noop_flag, tensor_lists, scale)
-
     def multi_tensor_l2norm(
         self,
         chunk_size: int,
         noop_flag: torch.Tensor,
         tensor_lists: List[List[torch.Tensor]],
-        per_tensor: bool = False,
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
-        result, _ = multi_tensor_l2_norm_fl(chunk_size, noop_flag, tensor_lists, per_tensor)
-        return result
-
+        per_tensor: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return multi_tensor_l2_norm_fl(chunk_size, noop_flag, tensor_lists, per_tensor)
     def multi_tensor_adam(
         self,
-        chunk_size: int = None,
-        noop_flag: torch.Tensor = None,
-        tensor_lists: List[List[torch.Tensor]] = None,
-        lr: float = None,
-        beta1: float = None,
-        beta2: float = None,
-        eps: float = None,
-        step: int = None,
-        mode: int = None,
-        bias_correction: int = None,
-        weight_decay: float = None,
-    ):
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
         if chunk_size is None:
             return multi_tensor_adam_fl
         return multi_tensor_adam_fl(
             chunk_size=chunk_size, noop_flag=noop_flag, tensor_lists=tensor_lists,
-            lr=lr, beta1=beta1, beta2=beta2, eps=eps,
+            lr=lr, beta1=beta1, beta2=beta2, eps=epsilon,
             step=step, mode=mode, bias_correction=bias_correction, weight_decay=weight_decay,
         )
-
     def multi_tensor_adam_param_remainder(
         self,
-        chunk_size: int = None,
-        noop_flag: torch.Tensor = None,
-        tensor_lists: List[List[torch.Tensor]] = None,
-        lr: float = None,
-        beta1: float = None,
-        beta2: float = None,
-        eps: float = None,
-        step: int = None,
-        mode: int = None,
-        bias_correction: int = None,
-        weight_decay: float = None,
-    ):
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
         if chunk_size is None:
             return multi_tensor_adam_param_remainder_fl
         return multi_tensor_adam_param_remainder_fl(
             chunk_size=chunk_size, noop_flag=noop_flag, tensor_lists=tensor_lists,
-            lr=lr, beta1=beta1, beta2=beta2, eps=eps,
+            lr=lr, beta1=beta1, beta2=beta2, eps=epsilon,
             step=step, mode=mode, bias_correction=bias_correction, weight_decay=weight_decay,
         )
 
+    # Misc
     def get_cublasLt_version(self) -> int:
         return 110000
-
     def get_cudnn_version(self) -> int:
         return 90000
-
     def get_num_cublas_streams(self) -> int:
         return 0
 
-    def get_fused_attn_backend(self, *args, **kwargs) -> int:
-        return NVTE_Fused_Attn_Backend.NVTE_No_Backend
-
-    def create_fp8_tensor_meta(self) -> FP8TensorMeta:
-        return FP8TensorMeta()
-
+############## class func #################################
+    def get_flash_attention_class(self):
+        from .attention.dot_product_attention.backends import FlashAttentionFL
+        return FlashAttentionFL

--- a/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
@@ -14,7 +14,7 @@ def multi_tensor_adam_fl(
     lr: float,
     beta1: float,
     beta2: float,
-    epsilon: float,
+    eps: float,
     step: int,
     mode: int,
     bias_correction: int,
@@ -22,12 +22,7 @@ def multi_tensor_adam_fl(
     inv_scale: Optional[float] = 1.0,
     out_dtype: Optional[torch.dtype] = None,
 ) -> None:
-    """
-    Adam optimizer implementation matching CUDA exactly.
 
-    mode == 0: L2 regularization (add weight_decay * param to gradient before moment update)
-    mode == 1: AdamW (add weight_decay * param to update after moment computation)
-    """
     num_lists = len(tensor_lists)
     assert num_lists in [4, 5], f"Expected 4 or 5 tensor lists, got {num_lists}"
 
@@ -55,51 +50,32 @@ def multi_tensor_adam_fl(
         if not g.is_contiguous():
             g = g.contiguous()
 
-        # Convert to float for computation (matches CUDA's MATH_T = float)
-        g = g.float()
-        p_float = p.float()
-
         if inv_scale is not None and inv_scale != 1.0:
             g = flag_gems.mul(g, inv_scale)
 
-        if mode == 0:  # L2 regularization
-            # Add weight decay to gradient before moment update
-            g = flag_gems.add(g, p_float, alpha=weight_decay)
+        m = flag_gems.add_(flag_gems.mul_(m, beta1), g, alpha=1-beta1)
+        v = flag_gems.add_(flag_gems.mul_(v, beta2), flag_gems.mul_(flag_gems.mul_(g, g), 1 - beta2))
 
-            # Update moments with modified gradient
-            flag_gems.add_(flag_gems.mul_(m, beta1), g, alpha=1-beta1)
-            flag_gems.add_(flag_gems.mul_(v, beta2), flag_gems.mul(g, g), alpha=1-beta2)
+        m_corr = m.clone()
+        v_corr = v.clone()
+        if bias_correction == 1:
+            m_corr = flag_gems.true_divide(m_corr, bias_correction1)
+            v_corr = flag_gems.true_divide(v_corr, bias_correction2)
 
-            # Bias correction
-            m_corr = flag_gems.true_divide(m, bias_correction1)
-            v_corr = flag_gems.true_divide(v, bias_correction2)
+        update = flag_gems.true_divide(m_corr, flag_gems.add(flag_gems.sqrt(v_corr), eps))
 
-            # Compute update
-            denom = flag_gems.add(flag_gems.sqrt(v_corr), epsilon)
-            update = flag_gems.true_divide(m_corr, denom)
+        if is_adamw:
+            p = flag_gems.mul_(p, 1 - lr * weight_decay)
+        else:
+            update = flag_gems.add_(update, p, alpha=weight_decay)
 
-            # Update parameter
-            p.add_(update, alpha=-lr)
-        else:  # mode == 1, AdamW (decoupled weight decay)
-            # Update moments with original gradient
-            flag_gems.add_(flag_gems.mul_(m, beta1), g, alpha=1-beta1)
-            flag_gems.add_(flag_gems.mul_(v, beta2), flag_gems.mul(g, g), alpha=1-beta2)
-
-            # Bias correction
-            m_corr = flag_gems.true_divide(m, bias_correction1)
-            v_corr = flag_gems.true_divide(v, bias_correction2)
-
-            # Compute update with weight decay added (matches CUDA exactly)
-            denom = flag_gems.add(flag_gems.sqrt(v_corr), epsilon)
-            update = flag_gems.add(flag_gems.true_divide(m_corr, denom), p_float, alpha=weight_decay)
-
-            # Update parameter
-            p.add_(update, alpha=-lr)
+        p = flag_gems.add_(p, update, alpha=-lr)
 
         if p_master is not None:
             flag_gems.copy_(p_master, p)
             out_dtype = p_master.dtype if out_dtype is None else out_dtype
             p.data = p.data.to(out_dtype)
+
 
 def multi_tensor_adam_param_remainder_fl(
     chunk_size: int,
@@ -108,14 +84,32 @@ def multi_tensor_adam_param_remainder_fl(
     lr: float,
     beta1: float,
     beta2: float,
-    epsilon: float,
+    eps: float,
     step: int,
     mode: int,
     bias_correction: int,
     weight_decay: float,
+    inv_scale: Optional[float] = 1.0,
 ) -> None:
     """
     Adam optimizer with parameter remainders for BF16 precision (FlagOS implementation).
+
+    This variant stores BF16 parameters + int16 remainders to reconstruct FP32 master weights.
+    Used when you have BF16 params and need FP32 master params without storing full FP32 copies.
+
+    Args:
+        chunk_size: Chunk size for processing (unused in this implementation)
+        noop_flag: If non-zero, skip computation
+        tensor_lists: [grads, params (bf16), exp_avgs (fp32), exp_avg_sqs (fp32), param_remainders (int16)]
+        lr: Learning rate
+        beta1: First moment decay rate
+        beta2: Second moment decay rate
+        eps: Epsilon for numerical stability
+        step: Current optimization step
+        mode: 0 = L2 regularization, 1 = AdamW (decoupled weight decay)
+        bias_correction: Whether to apply bias correction (1 = yes, 0 = no)
+        weight_decay: Weight decay coefficient
+        inv_scale: Inverse gradient scale for mixed precision training
     """
     if noop_flag.item() != 0:
         return
@@ -139,78 +133,58 @@ def multi_tensor_adam_param_remainder_fl(
 
     for i in range(num_tensors):
         g = tensor_lists[0][i]
-        p = tensor_lists[1][i]  # int16 parameter (high 16 bits of FP32)
+        p = tensor_lists[1][i]  # BF16 parameter
         m = tensor_lists[2][i]  # FP32 first moment
         v = tensor_lists[3][i]  # FP32 second moment
-        p_remainder = tensor_lists[4][i]  # int16 remainder (low 16 bits of FP32)
+        p_remainder = tensor_lists[4][i]  # int16 remainder
 
         if not g.is_contiguous():
             g = g.contiguous()
 
-        # Convert gradient to float
-        g_float = g.float()
+        # Apply gradient unscaling if needed
+        if inv_scale is not None and inv_scale != 1.0:
+            g = flag_gems.mul(g, inv_scale)
 
-        # Reconstruct FP32 master weight from int16 param + int16 remainder using bit manipulation
-        # This matches the CUDA implementation exactly:
-        # 1. If p_remainder < 0, decrement p (undo rounding)
-        # 2. Combine high 16 bits (p) and low 16 bits (p_remainder) into FP32
-        # Note: Use PyTorch native ops for bit manipulation (int16/int32 operations)
+        # Reconstruct FP32 master weight from BF16 param + int16 remainder
+        # The remainder represents the lower 16 bits lost in BF16 conversion
+        param_fp32 = p.float()
+        param_master = flag_gems.add(param_fp32, flag_gems.mul(p_remainder.float(), 2.0 ** -16))
 
-        local_p = p.view(torch.int16).clone()
-        local_p_rem = p_remainder.clone()
+        # Compute gradient with weight decay (if L2 mode)
+        grad_with_decay = g.float()
+        if not is_adamw:  # L2 regularization mode
+            grad_with_decay = flag_gems.add(grad_with_decay, flag_gems.mul(param_master, weight_decay))
 
-        # Undo rounding: if remainder < 0, decrement p
-        local_p = torch.where(local_p_rem < 0, local_p - 1, local_p)
-
-        # Combine into FP32 using bit shift operations
-        # local_p is high 16 bits, local_p_rem is low 16 bits
-        high_bits = local_p.to(torch.int32) << 16
-        low_bits = local_p_rem.to(torch.int32) & 0xFFFF  # Mask off sign extension
-        param_int32 = high_bits | low_bits
-        param_master = param_int32.view(torch.float32)
-
-        # L2 mode: add weight decay to gradient before updating moments
-        if not is_adamw and weight_decay != 0:
-            g_float = flag_gems.add(g_float, param_master, alpha=weight_decay)
-
-        # Update first moment: m = beta1 * m + (1 - beta1) * g
-        flag_gems.add_(flag_gems.mul_(m, beta1), g_float, alpha=1 - beta1)
-
-        # Update second moment: v = beta2 * v + (1 - beta2) * g^2
-        flag_gems.add_(flag_gems.mul_(v, beta2), flag_gems.mul(g_float, g_float), alpha=1 - beta2)
+        # Update moments
+        m = flag_gems.add_(flag_gems.mul_(m, beta1), grad_with_decay, alpha=1 - beta1)
+        v = flag_gems.add_(flag_gems.mul_(v, beta2), flag_gems.mul_(flag_gems.mul_(grad_with_decay, grad_with_decay), 1 - beta2))
 
         # Apply bias correction
-        m_corr = flag_gems.true_divide(m, bias_correction1)
-        v_corr = flag_gems.true_divide(v, bias_correction2)
-
-        # Compute denominator: sqrt(v_corr) + epsilon
-        denom = flag_gems.add(flag_gems.sqrt(v_corr), epsilon)
+        m_corr = m.clone()
+        v_corr = v.clone()
+        if bias_correction == 1:
+            m_corr = flag_gems.true_divide(m_corr, bias_correction1)
+            v_corr = flag_gems.true_divide(v_corr, bias_correction2)
 
         # Compute update
-        update = flag_gems.true_divide(m_corr, denom)
+        update = flag_gems.true_divide(m_corr, flag_gems.add(flag_gems.sqrt(v_corr), eps))
 
-        # AdamW mode: add decoupled weight decay to update
-        if is_adamw and weight_decay != 0:
-            update = flag_gems.add(update, param_master, alpha=weight_decay)
+        # Apply weight decay (if AdamW mode)
+        if is_adamw:
+            param_master = flag_gems.mul_(param_master, 1 - lr * weight_decay)
 
-        # Update master weight: p = p - lr * update
-        param_master = flag_gems.sub(param_master, flag_gems.mul(update, lr))
+        # Update master weight
+        param_master = flag_gems.add_(param_master, update, alpha=-lr)
 
-        # Split FP32 back into int16 param + int16 remainder using bit manipulation
-        # This matches the CUDA implementation exactly:
-        # 1. Extract high 16 bits as p
-        # 2. Extract low 16 bits as p_remainder
-        # 3. If p_remainder < 0, increment p (round up)
-        # Note: Use PyTorch native ops for bit manipulation (int32 operations)
+        # Split back into BF16 param + int16 remainder
+        # Convert to BF16 (this is the rounded version)
+        param_bf16 = param_master.to(dtype=p.dtype)
 
-        param_int32 = param_master.view(torch.int32)
-        # Extract low 16 bits (remainder) and high 16 bits (param)
-        new_p_rem = (param_int32 & 0xFFFF).to(torch.int16)
-        new_p = ((param_int32 >> 16) & 0xFFFF).to(torch.int16)
-
-        # Round up: if remainder < 0, increment p
-        new_p = torch.where(new_p_rem < 0, new_p + 1, new_p)
+        # Compute remainder: difference between FP32 master and BF16 representation
+        # Scale and quantize to int16 range
+        remainder_fp32 = flag_gems.mul(flag_gems.sub(param_master, param_bf16.float()), 2.0 ** 16)
+        remainder_int16 = flag_gems.clamp(torch.round(remainder_fp32), -32768, 32767).to(dtype=torch.int16)
 
         # Write back
-        flag_gems.copy_(p, new_p.view(torch.bfloat16))
-        flag_gems.copy_(p_remainder, new_p_rem)
+        flag_gems.copy_(p, param_bf16)
+        flag_gems.copy_(p_remainder, remainder_int16)

--- a/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
@@ -212,5 +212,5 @@ def multi_tensor_adam_param_remainder_fl(
         new_p = torch.where(new_p_rem < 0, new_p + 1, new_p)
 
         # Write back
-        p.view(torch.int16).copy_(new_p)
-        p_remainder.copy_(new_p_rem)
+        flag_gems.copy_(p, new_p.view(torch.bfloat16))
+        flag_gems.copy_(p_remainder, new_p_rem)

--- a/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/fused_adam.py
@@ -14,7 +14,7 @@ def multi_tensor_adam_fl(
     lr: float,
     beta1: float,
     beta2: float,
-    eps: float,
+    epsilon: float,
     step: int,
     mode: int,
     bias_correction: int,
@@ -22,7 +22,12 @@ def multi_tensor_adam_fl(
     inv_scale: Optional[float] = 1.0,
     out_dtype: Optional[torch.dtype] = None,
 ) -> None:
+    """
+    Adam optimizer implementation matching CUDA exactly.
 
+    mode == 0: L2 regularization (add weight_decay * param to gradient before moment update)
+    mode == 1: AdamW (add weight_decay * param to update after moment computation)
+    """
     num_lists = len(tensor_lists)
     assert num_lists in [4, 5], f"Expected 4 or 5 tensor lists, got {num_lists}"
 
@@ -50,32 +55,51 @@ def multi_tensor_adam_fl(
         if not g.is_contiguous():
             g = g.contiguous()
 
+        # Convert to float for computation (matches CUDA's MATH_T = float)
+        g = g.float()
+        p_float = p.float()
+
         if inv_scale is not None and inv_scale != 1.0:
             g = flag_gems.mul(g, inv_scale)
 
-        m = flag_gems.add_(flag_gems.mul_(m, beta1), g, alpha=1-beta1)
-        v = flag_gems.add_(flag_gems.mul_(v, beta2), flag_gems.mul_(flag_gems.mul_(g, g), 1 - beta2))
+        if mode == 0:  # L2 regularization
+            # Add weight decay to gradient before moment update
+            g = flag_gems.add(g, p_float, alpha=weight_decay)
 
-        m_corr = m.clone()
-        v_corr = v.clone()
-        if bias_correction == 1:
-            m_corr = flag_gems.true_divide(m_corr, bias_correction1)
-            v_corr = flag_gems.true_divide(v_corr, bias_correction2)
+            # Update moments with modified gradient
+            flag_gems.add_(flag_gems.mul_(m, beta1), g, alpha=1-beta1)
+            flag_gems.add_(flag_gems.mul_(v, beta2), flag_gems.mul(g, g), alpha=1-beta2)
 
-        update = flag_gems.true_divide(m_corr, flag_gems.add(flag_gems.sqrt(v_corr), eps))
+            # Bias correction
+            m_corr = flag_gems.true_divide(m, bias_correction1)
+            v_corr = flag_gems.true_divide(v, bias_correction2)
 
-        if is_adamw:
-            p = flag_gems.mul_(p, 1 - lr * weight_decay)
-        else:
-            update = flag_gems.add_(update, p, alpha=weight_decay)
+            # Compute update
+            denom = flag_gems.add(flag_gems.sqrt(v_corr), epsilon)
+            update = flag_gems.true_divide(m_corr, denom)
 
-        p = flag_gems.add_(p, update, alpha=-lr)
+            # Update parameter
+            p.add_(update, alpha=-lr)
+        else:  # mode == 1, AdamW (decoupled weight decay)
+            # Update moments with original gradient
+            flag_gems.add_(flag_gems.mul_(m, beta1), g, alpha=1-beta1)
+            flag_gems.add_(flag_gems.mul_(v, beta2), flag_gems.mul(g, g), alpha=1-beta2)
+
+            # Bias correction
+            m_corr = flag_gems.true_divide(m, bias_correction1)
+            v_corr = flag_gems.true_divide(v, bias_correction2)
+
+            # Compute update with weight decay added (matches CUDA exactly)
+            denom = flag_gems.add(flag_gems.sqrt(v_corr), epsilon)
+            update = flag_gems.add(flag_gems.true_divide(m_corr, denom), p_float, alpha=weight_decay)
+
+            # Update parameter
+            p.add_(update, alpha=-lr)
 
         if p_master is not None:
             flag_gems.copy_(p_master, p)
             out_dtype = p_master.dtype if out_dtype is None else out_dtype
             p.data = p.data.to(out_dtype)
-
 
 def multi_tensor_adam_param_remainder_fl(
     chunk_size: int,
@@ -84,32 +108,14 @@ def multi_tensor_adam_param_remainder_fl(
     lr: float,
     beta1: float,
     beta2: float,
-    eps: float,
+    epsilon: float,
     step: int,
     mode: int,
     bias_correction: int,
     weight_decay: float,
-    inv_scale: Optional[float] = 1.0,
 ) -> None:
     """
     Adam optimizer with parameter remainders for BF16 precision (FlagOS implementation).
-
-    This variant stores BF16 parameters + int16 remainders to reconstruct FP32 master weights.
-    Used when you have BF16 params and need FP32 master params without storing full FP32 copies.
-
-    Args:
-        chunk_size: Chunk size for processing (unused in this implementation)
-        noop_flag: If non-zero, skip computation
-        tensor_lists: [grads, params (bf16), exp_avgs (fp32), exp_avg_sqs (fp32), param_remainders (int16)]
-        lr: Learning rate
-        beta1: First moment decay rate
-        beta2: Second moment decay rate
-        eps: Epsilon for numerical stability
-        step: Current optimization step
-        mode: 0 = L2 regularization, 1 = AdamW (decoupled weight decay)
-        bias_correction: Whether to apply bias correction (1 = yes, 0 = no)
-        weight_decay: Weight decay coefficient
-        inv_scale: Inverse gradient scale for mixed precision training
     """
     if noop_flag.item() != 0:
         return
@@ -133,58 +139,78 @@ def multi_tensor_adam_param_remainder_fl(
 
     for i in range(num_tensors):
         g = tensor_lists[0][i]
-        p = tensor_lists[1][i]  # BF16 parameter
+        p = tensor_lists[1][i]  # int16 parameter (high 16 bits of FP32)
         m = tensor_lists[2][i]  # FP32 first moment
         v = tensor_lists[3][i]  # FP32 second moment
-        p_remainder = tensor_lists[4][i]  # int16 remainder
+        p_remainder = tensor_lists[4][i]  # int16 remainder (low 16 bits of FP32)
 
         if not g.is_contiguous():
             g = g.contiguous()
 
-        # Apply gradient unscaling if needed
-        if inv_scale is not None and inv_scale != 1.0:
-            g = flag_gems.mul(g, inv_scale)
+        # Convert gradient to float
+        g_float = g.float()
 
-        # Reconstruct FP32 master weight from BF16 param + int16 remainder
-        # The remainder represents the lower 16 bits lost in BF16 conversion
-        param_fp32 = p.float()
-        param_master = flag_gems.add(param_fp32, flag_gems.mul(p_remainder.float(), 2.0 ** -16))
+        # Reconstruct FP32 master weight from int16 param + int16 remainder using bit manipulation
+        # This matches the CUDA implementation exactly:
+        # 1. If p_remainder < 0, decrement p (undo rounding)
+        # 2. Combine high 16 bits (p) and low 16 bits (p_remainder) into FP32
+        # Note: Use PyTorch native ops for bit manipulation (int16/int32 operations)
 
-        # Compute gradient with weight decay (if L2 mode)
-        grad_with_decay = g.float()
-        if not is_adamw:  # L2 regularization mode
-            grad_with_decay = flag_gems.add(grad_with_decay, flag_gems.mul(param_master, weight_decay))
+        local_p = p.view(torch.int16).clone()
+        local_p_rem = p_remainder.clone()
 
-        # Update moments
-        m = flag_gems.add_(flag_gems.mul_(m, beta1), grad_with_decay, alpha=1 - beta1)
-        v = flag_gems.add_(flag_gems.mul_(v, beta2), flag_gems.mul_(flag_gems.mul_(grad_with_decay, grad_with_decay), 1 - beta2))
+        # Undo rounding: if remainder < 0, decrement p
+        local_p = torch.where(local_p_rem < 0, local_p - 1, local_p)
+
+        # Combine into FP32 using bit shift operations
+        # local_p is high 16 bits, local_p_rem is low 16 bits
+        high_bits = local_p.to(torch.int32) << 16
+        low_bits = local_p_rem.to(torch.int32) & 0xFFFF  # Mask off sign extension
+        param_int32 = high_bits | low_bits
+        param_master = param_int32.view(torch.float32)
+
+        # L2 mode: add weight decay to gradient before updating moments
+        if not is_adamw and weight_decay != 0:
+            g_float = flag_gems.add(g_float, param_master, alpha=weight_decay)
+
+        # Update first moment: m = beta1 * m + (1 - beta1) * g
+        flag_gems.add_(flag_gems.mul_(m, beta1), g_float, alpha=1 - beta1)
+
+        # Update second moment: v = beta2 * v + (1 - beta2) * g^2
+        flag_gems.add_(flag_gems.mul_(v, beta2), flag_gems.mul(g_float, g_float), alpha=1 - beta2)
 
         # Apply bias correction
-        m_corr = m.clone()
-        v_corr = v.clone()
-        if bias_correction == 1:
-            m_corr = flag_gems.true_divide(m_corr, bias_correction1)
-            v_corr = flag_gems.true_divide(v_corr, bias_correction2)
+        m_corr = flag_gems.true_divide(m, bias_correction1)
+        v_corr = flag_gems.true_divide(v, bias_correction2)
+
+        # Compute denominator: sqrt(v_corr) + epsilon
+        denom = flag_gems.add(flag_gems.sqrt(v_corr), epsilon)
 
         # Compute update
-        update = flag_gems.true_divide(m_corr, flag_gems.add(flag_gems.sqrt(v_corr), eps))
+        update = flag_gems.true_divide(m_corr, denom)
 
-        # Apply weight decay (if AdamW mode)
-        if is_adamw:
-            param_master = flag_gems.mul_(param_master, 1 - lr * weight_decay)
+        # AdamW mode: add decoupled weight decay to update
+        if is_adamw and weight_decay != 0:
+            update = flag_gems.add(update, param_master, alpha=weight_decay)
 
-        # Update master weight
-        param_master = flag_gems.add_(param_master, update, alpha=-lr)
+        # Update master weight: p = p - lr * update
+        param_master = flag_gems.sub(param_master, flag_gems.mul(update, lr))
 
-        # Split back into BF16 param + int16 remainder
-        # Convert to BF16 (this is the rounded version)
-        param_bf16 = param_master.to(dtype=p.dtype)
+        # Split FP32 back into int16 param + int16 remainder using bit manipulation
+        # This matches the CUDA implementation exactly:
+        # 1. Extract high 16 bits as p
+        # 2. Extract low 16 bits as p_remainder
+        # 3. If p_remainder < 0, increment p (round up)
+        # Note: Use PyTorch native ops for bit manipulation (int32 operations)
 
-        # Compute remainder: difference between FP32 master and BF16 representation
-        # Scale and quantize to int16 range
-        remainder_fp32 = flag_gems.mul(flag_gems.sub(param_master, param_bf16.float()), 2.0 ** 16)
-        remainder_int16 = flag_gems.clamp(torch.round(remainder_fp32), -32768, 32767).to(dtype=torch.int16)
+        param_int32 = param_master.view(torch.int32)
+        # Extract low 16 bits (remainder) and high 16 bits (param)
+        new_p_rem = (param_int32 & 0xFFFF).to(torch.int16)
+        new_p = ((param_int32 >> 16) & 0xFFFF).to(torch.int16)
+
+        # Round up: if remainder < 0, increment p
+        new_p = torch.where(new_p_rem < 0, new_p + 1, new_p)
 
         # Write back
-        flag_gems.copy_(p, param_bf16)
-        flag_gems.copy_(p_remainder, remainder_int16)
+        p.view(torch.int16).copy_(new_p)
+        p_remainder.copy_(new_p_rem)

--- a/transformer_engine/plugin/core/backends/flagos/impl/multi_tensor.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/multi_tensor.py
@@ -34,6 +34,9 @@ def multi_tensor_l2_norm_fl(
 
     for tensor in tensors:
         norm_sq = flag_gems.sum(tensor.float() ** 2)
+        # Check for inf/nan (matches CUDA behavior)
+        if not torch.isfinite(norm_sq):
+            noop_flag.fill_(1)
         total_norm_sq = total_norm_sq + norm_sq
         if per_tensor:
             per_tensor_norms.append(flag_gems.sqrt(norm_sq))
@@ -47,7 +50,6 @@ def multi_tensor_l2_norm_fl(
 
     return total_norm, per_tensor_result
 
-
 def multi_tensor_scale_fl(
     _chunk_size: int,
     noop_flag: torch.Tensor,
@@ -58,4 +60,7 @@ def multi_tensor_scale_fl(
         return
 
     for src, dst in zip(tensor_lists[0], tensor_lists[1]):
+        # Check for inf/nan (matches CUDA behavior for AMP gradient scaling)
+        if not torch.isfinite(src).all():
+            noop_flag.fill_(1)
         flag_gems.copy_(dst, src * scale)

--- a/transformer_engine/plugin/core/backends/flagos/impl/multi_tensor.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/multi_tensor.py
@@ -2,65 +2,25 @@
 #
 # See LICENSE for license information.
 
-from typing import List, Tuple
 import torch
+from torch.distributed._tensor import DTensor
 import flag_gems
 
 
-def multi_tensor_l2_norm_fl(
-    _chunk_size: int,
-    noop_flag: torch.Tensor,
-    tensor_lists: List[List[torch.Tensor]],
-    per_tensor: bool = False,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Compute L2 norm of tensors using flag_gems.
-
-    Returns:
-        Tuple of (total_norm, per_tensor_norms_or_dummy)
-        - total_norm: The combined L2 norm of all tensors
-        - per_tensor_norms_or_dummy: Per-tensor norms stacked if per_tensor=True, else dummy tensor
-    """
-    device = tensor_lists[0][0].device if tensor_lists and tensor_lists[0] else 'cpu'
-
-    if noop_flag.item() != 0:
-        return torch.tensor(0.0, device=device), torch.tensor(0.0, device=device)
+def multi_tensor_l2_norm_fl(chunk_size, noop_flag, tensor_lists, per_tensor, *args):
 
     tensors = tensor_lists[0]
 
-    # Compute per-tensor norms
-    per_tensor_norms = []
-    total_norm_sq = torch.tensor(0.0, device=device)
-
-    for tensor in tensors:
-        norm_sq = flag_gems.sum(tensor.float() ** 2)
-        # Check for inf/nan (matches CUDA behavior)
-        if not torch.isfinite(norm_sq):
-            noop_flag.fill_(1)
-        total_norm_sq = total_norm_sq + norm_sq
-        if per_tensor:
-            per_tensor_norms.append(flag_gems.sqrt(norm_sq))
-
-    total_norm = flag_gems.sqrt(total_norm_sq)
-
     if per_tensor:
-        per_tensor_result = torch.stack(per_tensor_norms)
+        norms = [torch.norm(t.float(), p=2) for t in tensors]
+        return norms, None
     else:
-        per_tensor_result = torch.tensor(0.0, device=device)
+        total_norm_sq = sum(flag_gems.sum(flag_gems.pow_func(t.float(), 2)) for t in tensors)
+        total_norm = flag_gems.sqrt(total_norm_sq)
+        return total_norm, None
 
-    return total_norm, per_tensor_result
 
-def multi_tensor_scale_fl(
-    _chunk_size: int,
-    noop_flag: torch.Tensor,
-    tensor_lists: List[List[torch.Tensor]],
-    scale: float,
-) -> None:
-    if noop_flag.item() != 0:
-        return
+def multi_tensor_scale_fl(chunk_size, noop_flag, tensor_lists, scale):
 
     for src, dst in zip(tensor_lists[0], tensor_lists[1]):
-        # Check for inf/nan (matches CUDA behavior for AMP gradient scaling)
-        if not torch.isfinite(src).all():
-            noop_flag.fill_(1)
         flag_gems.copy_(dst, src * scale)

--- a/transformer_engine/plugin/core/backends/flagos/impl/multi_tensor.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/multi_tensor.py
@@ -2,25 +2,60 @@
 #
 # See LICENSE for license information.
 
+from typing import List, Tuple
 import torch
-from torch.distributed._tensor import DTensor
 import flag_gems
 
 
-def multi_tensor_l2_norm_fl(chunk_size, noop_flag, tensor_lists, per_tensor, *args):
+def multi_tensor_l2_norm_fl(
+    _chunk_size: int,
+    noop_flag: torch.Tensor,
+    tensor_lists: List[List[torch.Tensor]],
+    per_tensor: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Compute L2 norm of tensors using flag_gems.
+
+    Returns:
+        Tuple of (total_norm, per_tensor_norms_or_dummy)
+        - total_norm: The combined L2 norm of all tensors
+        - per_tensor_norms_or_dummy: Per-tensor norms stacked if per_tensor=True, else dummy tensor
+    """
+    device = tensor_lists[0][0].device if tensor_lists and tensor_lists[0] else 'cpu'
+
+    if noop_flag.item() != 0:
+        return torch.tensor(0.0, device=device), torch.tensor(0.0, device=device)
 
     tensors = tensor_lists[0]
 
+    # Compute per-tensor norms
+    per_tensor_norms = []
+    total_norm_sq = torch.tensor(0.0, device=device)
+
+    for tensor in tensors:
+        norm_sq = flag_gems.sum(tensor.float() ** 2)
+        total_norm_sq = total_norm_sq + norm_sq
+        if per_tensor:
+            per_tensor_norms.append(flag_gems.sqrt(norm_sq))
+
+    total_norm = flag_gems.sqrt(total_norm_sq)
+
     if per_tensor:
-        norms = [torch.norm(t.float(), p=2) for t in tensors]
-        return norms, None
+        per_tensor_result = torch.stack(per_tensor_norms)
     else:
-        total_norm_sq = sum(flag_gems.sum(flag_gems.pow_func(t.float(), 2)) for t in tensors)
-        total_norm = flag_gems.sqrt(total_norm_sq)
-        return total_norm, None
+        per_tensor_result = torch.tensor(0.0, device=device)
+
+    return total_norm, per_tensor_result
 
 
-def multi_tensor_scale_fl(chunk_size, noop_flag, tensor_lists, scale):
+def multi_tensor_scale_fl(
+    _chunk_size: int,
+    noop_flag: torch.Tensor,
+    tensor_lists: List[List[torch.Tensor]],
+    scale: float,
+) -> None:
+    if noop_flag.item() != 0:
+        return
 
     for src, dst in zip(tensor_lists[0], tensor_lists[1]):
         flag_gems.copy_(dst, src * scale)

--- a/transformer_engine/plugin/core/backends/flagos/impl/rmsnorm.py
+++ b/transformer_engine/plugin/core/backends/flagos/impl/rmsnorm.py
@@ -42,7 +42,7 @@ def rmsnorm_bwd_fl(
     gamma,
     sm_margin,
     zero_centered_gamma,
-    eps,
+    eps=1e-5,
 ):
     # When zero_centered_gamma is True, forward uses (1 + gamma) as weight
     # So backward needs to use (1 + gamma) for computing dx

--- a/transformer_engine/plugin/core/backends/reference/impl/optimizer.py
+++ b/transformer_engine/plugin/core/backends/reference/impl/optimizer.py
@@ -2,7 +2,7 @@
 #
 # See LICENSE for license information.
 
-from typing import List, Tuple, Union
+from typing import List, Union
 import torch
 
 __all__ = [
@@ -13,6 +13,7 @@ __all__ = [
     "multi_tensor_sgd_torch",
     "multi_tensor_compute_scale_and_scale_inv_torch",
 ]
+
 
 def multi_tensor_scale_torch(
     chunk_size: int,
@@ -32,53 +33,35 @@ def multi_tensor_scale_torch(
         raise ValueError("Output and input tensor lists must have the same length")
 
     for in_tensor, out_tensor in zip(input_tensors, output_tensors):
-        # Check for inf/nan (matches CUDA behavior for AMP gradient scaling)
-        if not torch.isfinite(in_tensor).all():
-            noop_flag.fill_(1)
         out_tensor.copy_(in_tensor * scale)
+
 
 def multi_tensor_l2norm_torch(
     chunk_size: int,
     noop_flag: torch.Tensor,
     tensor_lists: List[List[torch.Tensor]],
     per_tensor: bool = False,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Compute L2 norm of tensors.
-
-    Returns:
-        Tuple of (total_norm, per_tensor_norms_or_dummy)
-        - total_norm: The combined L2 norm of all tensors
-        - per_tensor_norms_or_dummy: Per-tensor norms stacked if per_tensor=True, else dummy tensor
-    """
-    device = tensor_lists[0][0].device if tensor_lists and tensor_lists[0] else 'cpu'
-
+) -> Union[torch.Tensor, List[torch.Tensor]]:
     if noop_flag.item() != 0:
-        return torch.tensor(0.0, device=device), torch.tensor(0.0, device=device)
+        if per_tensor:
+            return [torch.tensor(0.0, device=t.device) for t in tensor_lists[0]]
+        else:
+            return torch.tensor(0.0, device=tensor_lists[0][0].device)
 
     tensors = tensor_lists[0]
 
-    # Compute per-tensor norms
-    per_tensor_norms = []
-    total_norm_sq = torch.tensor(0.0, device=device)
-
-    for tensor in tensors:
-        norm_sq = torch.sum(tensor.float() ** 2)
-        # Check for inf/nan (matches CUDA behavior)
-        if not torch.isfinite(norm_sq):
-            noop_flag.fill_(1)
-        total_norm_sq = total_norm_sq + norm_sq
-        if per_tensor:
-            per_tensor_norms.append(torch.sqrt(norm_sq))
-
-    total_norm = torch.sqrt(total_norm_sq)
-
     if per_tensor:
-        per_tensor_result = torch.stack(per_tensor_norms)
+        norms = []
+        for tensor in tensors:
+            norm = torch.norm(tensor.float(), p=2)
+            norms.append(norm)
+        return norms
     else:
-        per_tensor_result = torch.tensor(0.0, device=device)
+        total_norm_sq = torch.tensor(0.0, device=tensors[0].device)
+        for tensor in tensors:
+            total_norm_sq += torch.sum(tensor.float() ** 2)
+        return torch.sqrt(total_norm_sq)
 
-    return total_norm, per_tensor_result
 
 def multi_tensor_adam_torch(
     chunk_size: int,
@@ -87,18 +70,12 @@ def multi_tensor_adam_torch(
     lr: float,
     beta1: float,
     beta2: float,
-    epsilon: float,
+    eps: float,
     step: int,
     mode: int,
     bias_correction: int,
     weight_decay: float,
 ) -> None:
-    """
-    Adam optimizer implementation matching CUDA exactly.
-
-    mode == 0: L2 regularization (add weight_decay * param to gradient before moment update)
-    mode == 1: AdamW (add weight_decay * param to update after moment computation)
-    """
     if noop_flag.item() != 0:
         return
 
@@ -121,43 +98,19 @@ def multi_tensor_adam_torch(
         if grad is None:
             continue
 
-        # Convert to float for computation (matches CUDA's MATH_T = float)
-        g = grad.float()
-        p = param.float()
+        if mode == 1 and weight_decay != 0:
+            param.mul_(1 - lr * weight_decay)
 
-        if mode == 0:  # L2 regularization
-            # Add weight decay to gradient before moment update
-            g = g + weight_decay * p
+        exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
 
-            # Update moments with modified gradient
-            exp_avg.mul_(beta1).add_(g, alpha=1 - beta1)
-            exp_avg_sq.mul_(beta2).addcmul_(g, g, value=1 - beta2)
+        exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
 
-            # Bias correction
-            m_corr = exp_avg / bias_correction1
-            v_corr = exp_avg_sq / bias_correction2
+        corrected_exp_avg = exp_avg / bias_correction1
+        corrected_exp_avg_sq = exp_avg_sq / bias_correction2
 
-            # Compute update
-            denom = v_corr.sqrt().add_(epsilon)
-            update = m_corr / denom
+        denom = corrected_exp_avg_sq.sqrt().add_(eps)
+        param.addcdiv_(corrected_exp_avg, denom, value=-lr)
 
-            # Update parameter
-            param.add_(update, alpha=-lr)
-        else:  # mode == 1, AdamW (decoupled weight decay)
-            # Update moments with original gradient
-            exp_avg.mul_(beta1).add_(g, alpha=1 - beta1)
-            exp_avg_sq.mul_(beta2).addcmul_(g, g, value=1 - beta2)
-
-            # Bias correction
-            m_corr = exp_avg / bias_correction1
-            v_corr = exp_avg_sq / bias_correction2
-
-            # Compute update with weight decay added (matches CUDA exactly)
-            denom = v_corr.sqrt().add_(epsilon)
-            update = (m_corr / denom) + (weight_decay * p)
-
-            # Update parameter
-            param.add_(update, alpha=-lr)
 
 def multi_tensor_adam_param_remainder_torch(
     chunk_size: int,
@@ -166,7 +119,7 @@ def multi_tensor_adam_param_remainder_torch(
     lr: float,
     beta1: float,
     beta2: float,
-    epsilon: float,
+    eps: float,
     step: int,
     mode: int,
     bias_correction: int,
@@ -175,30 +128,17 @@ def multi_tensor_adam_param_remainder_torch(
     """
     Adam optimizer with parameter remainders for BF16 precision.
 
-    This variant stores BF16 parameters + int16 remainders to reconstruct FP32 master weights
-    using bit manipulation, matching the CUDA implementation exactly.
-
-    The CUDA implementation stores:
-    - p: int16 representing the high 16 bits of FP32 (viewed as BF16)
-    - p_remainder: int16 representing the low 16 bits of FP32
-
-    To reconstruct FP32:
-    - If p_remainder < 0, decrement p (undo rounding)
-    - Combine: fp32.int16[1] = p, fp32.int16[0] = p_remainder
-
-    To split FP32 back:
-    - p = fp32.int16[1] (high 16 bits)
-    - p_remainder = fp32.int16[0] (low 16 bits)
-    - If p_remainder < 0, increment p (round up)
+    This variant stores BF16 parameters + int16 remainders to reconstruct FP32 master weights.
+    Used when you have BF16 params and need FP32 master params without storing full FP32 copies.
 
     Args:
         chunk_size: Chunk size for processing (unused in PyTorch implementation)
         noop_flag: If non-zero, skip computation
-        tensor_lists: [grads, params (int16/bf16), exp_avgs (fp32), exp_avg_sqs (fp32), param_remainders (int16)]
+        tensor_lists: [grads, params (bf16), exp_avgs (fp32), exp_avg_sqs (fp32), param_remainders (int16)]
         lr: Learning rate
         beta1: First moment decay rate
         beta2: Second moment decay rate
-        epsilon: Epsilon for numerical stability
+        eps: Epsilon for numerical stability
         step: Current optimization step
         mode: 0 = L2 regularization, 1 = AdamW (decoupled weight decay)
         bias_correction: Whether to apply bias correction (1 = yes, 0 = no)
@@ -224,76 +164,62 @@ def multi_tensor_adam_param_remainder_torch(
         bias_correction1 = 1.0
         bias_correction2 = 1.0
 
-    is_adamw = (mode == 1)
-
     for grad, param, exp_avg, exp_avg_sq, param_remainder in zip(
         grads, params, exp_avgs, exp_avg_sqs, param_remainders
     ):
-        # Convert gradient to float
-        g_float = grad.float()
+        if grad is None:
+            continue
 
-        # Reconstruct FP32 master weight from int16 param + int16 remainder using bit manipulation
-        # This matches the CUDA implementation exactly:
-        # 1. If p_remainder < 0, decrement p (undo rounding)
-        # 2. Combine high 16 bits (p) and low 16 bits (p_remainder) into FP32
+        # Reconstruct FP32 master weight from BF16 param + int16 remainder
+        # The CUDA implementation uses bit manipulation to combine them
+        # In PyTorch, we approximate this by:
+        # 1. Convert param (bf16) to fp32 - this gives us the high-precision bits
+        # 2. Add the remainder scaled appropriately
+        param_fp32 = param.float()
 
-        local_p = param.view(torch.int16).clone()
-        local_p_rem = param_remainder.clone()
+        # The remainder represents the lower 16 bits lost in BF16 conversion
+        # We need to scale it back to the proper magnitude
+        # BF16 has 16 bits total (1 sign, 8 exponent, 7 mantissa)
+        # The remainder compensates for the lost precision
+        param_master = param_fp32 + param_remainder.float() * (2.0 ** -16)
 
-        # Undo rounding: if remainder < 0, decrement p
-        local_p = torch.where(local_p_rem < 0, local_p - 1, local_p)
+        # Standard Adam update on FP32 master weight
+        if mode == 0:  # L2 regularization
+            grad_with_decay = grad.float() + weight_decay * param_master
+        else:  # mode == 1, AdamW
+            grad_with_decay = grad.float()
 
-        # Combine into FP32 using bit shift operations
-        # local_p is high 16 bits, local_p_rem is low 16 bits
-        high_bits = local_p.to(torch.int32) << 16
-        low_bits = local_p_rem.to(torch.int32) & 0xFFFF  # Mask off sign extension
-        param_int32 = high_bits | low_bits
-        param_master = param_int32.view(torch.float32)
-
-        # L2 mode: add weight decay to gradient before updating moments
-        if not is_adamw and weight_decay != 0:
-            g_float = g_float + weight_decay * param_master
-
-        # Update first moment: m = beta1 * m + (1 - beta1) * g
-        exp_avg.mul_(beta1).add_(g_float, alpha=1 - beta1)
-
-        # Update second moment: v = beta2 * v + (1 - beta2) * g^2
-        exp_avg_sq.mul_(beta2).addcmul_(g_float, g_float, value=1 - beta2)
+        # Update moments
+        exp_avg.mul_(beta1).add_(grad_with_decay, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(grad_with_decay, grad_with_decay, value=1 - beta2)
 
         # Apply bias correction
-        m_corr = exp_avg / bias_correction1
-        v_corr = exp_avg_sq / bias_correction2
-
-        # Compute denominator: sqrt(v_corr) + epsilon
-        denom = torch.sqrt(v_corr) + epsilon
+        corrected_exp_avg = exp_avg / bias_correction1
+        corrected_exp_avg_sq = exp_avg_sq / bias_correction2
 
         # Compute update
-        update = m_corr / denom
+        denom = corrected_exp_avg_sq.sqrt().add_(eps)
+        update = corrected_exp_avg / denom
 
-        # AdamW mode: add decoupled weight decay to update
-        if is_adamw and weight_decay != 0:
+        if mode == 1:  # AdamW: apply weight decay directly
             update = update + weight_decay * param_master
 
-        # Update master weight: p = p - lr * update
-        param_master = param_master - lr * update
+        # Update master weight
+        param_master.add_(update, alpha=-lr)
 
-        # Split FP32 back into int16 param + int16 remainder using bit manipulation
-        # This matches the CUDA implementation exactly:
-        # 1. Extract high 16 bits as p
-        # 2. Extract low 16 bits as p_remainder
-        # 3. If p_remainder < 0, increment p (round up)
+        # Split back into BF16 param + int16 remainder
+        # Convert to BF16 (this is the rounded version)
+        param_bf16 = param_master.to(dtype=param.dtype)
 
-        param_int32 = param_master.view(torch.int32)
-        # Extract low 16 bits (remainder) and high 16 bits (param)
-        new_p_rem = (param_int32 & 0xFFFF).to(torch.int16)
-        new_p = ((param_int32 >> 16) & 0xFFFF).to(torch.int16)
-
-        # Round up: if remainder < 0, increment p
-        new_p = torch.where(new_p_rem < 0, new_p + 1, new_p)
+        # Compute remainder: difference between FP32 master and BF16 representation
+        # Scale and quantize to int16 range
+        remainder_fp32 = (param_master - param_bf16.float()) * (2.0 ** 16)
+        remainder_int16 = remainder_fp32.round().clamp(-32768, 32767).to(dtype=torch.int16)
 
         # Write back
-        param.view(torch.int16).copy_(new_p)
-        param_remainder.copy_(new_p_rem)
+        param.copy_(param_bf16)
+        param_remainder.copy_(remainder_int16)
+
 
 def multi_tensor_sgd_torch(
     chunk_size: int,
@@ -335,6 +261,7 @@ def multi_tensor_sgd_torch(
                 grad = buf
 
         param.add_(grad, alpha=-lr)
+
 
 def multi_tensor_compute_scale_and_scale_inv_torch(
     chunk_size: int,

--- a/transformer_engine/plugin/core/backends/reference/impl/optimizer.py
+++ b/transformer_engine/plugin/core/backends/reference/impl/optimizer.py
@@ -2,7 +2,7 @@
 #
 # See LICENSE for license information.
 
-from typing import List, Union
+from typing import List, Tuple, Union
 import torch
 
 __all__ = [
@@ -41,26 +41,40 @@ def multi_tensor_l2norm_torch(
     noop_flag: torch.Tensor,
     tensor_lists: List[List[torch.Tensor]],
     per_tensor: bool = False,
-) -> Union[torch.Tensor, List[torch.Tensor]]:
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Compute L2 norm of tensors.
+
+    Returns:
+        Tuple of (total_norm, per_tensor_norms_or_dummy)
+        - total_norm: The combined L2 norm of all tensors
+        - per_tensor_norms_or_dummy: Per-tensor norms stacked if per_tensor=True, else dummy tensor
+    """
+    device = tensor_lists[0][0].device if tensor_lists and tensor_lists[0] else 'cpu'
+
     if noop_flag.item() != 0:
-        if per_tensor:
-            return [torch.tensor(0.0, device=t.device) for t in tensor_lists[0]]
-        else:
-            return torch.tensor(0.0, device=tensor_lists[0][0].device)
+        return torch.tensor(0.0, device=device), torch.tensor(0.0, device=device)
 
     tensors = tensor_lists[0]
 
+    # Compute per-tensor norms
+    per_tensor_norms = []
+    total_norm_sq = torch.tensor(0.0, device=device)
+
+    for tensor in tensors:
+        norm_sq = torch.sum(tensor.float() ** 2)
+        total_norm_sq += norm_sq
+        if per_tensor:
+            per_tensor_norms.append(torch.sqrt(norm_sq))
+
+    total_norm = torch.sqrt(total_norm_sq)
+
     if per_tensor:
-        norms = []
-        for tensor in tensors:
-            norm = torch.norm(tensor.float(), p=2)
-            norms.append(norm)
-        return norms
+        per_tensor_result = torch.stack(per_tensor_norms)
     else:
-        total_norm_sq = torch.tensor(0.0, device=tensors[0].device)
-        for tensor in tensors:
-            total_norm_sq += torch.sum(tensor.float() ** 2)
-        return torch.sqrt(total_norm_sq)
+        per_tensor_result = torch.tensor(0.0, device=device)
+
+    return total_norm, per_tensor_result
 
 
 def multi_tensor_adam_torch(
@@ -225,12 +239,31 @@ def multi_tensor_sgd_torch(
     chunk_size: int,
     noop_flag: torch.Tensor,
     tensor_lists: List[List[torch.Tensor]],
-    lr: float,
+    wd: float,
     momentum: float,
     dampening: float,
-    weight_decay: float,
+    lr: float,
     nesterov: bool,
+    first_run: bool,
+    wd_after_momentum: bool,
+    scale: float,
 ) -> None:
+    """
+    SGD optimizer with momentum.
+
+    Args:
+        chunk_size: Chunk size (unused in PyTorch implementation)
+        noop_flag: If non-zero, skip computation
+        tensor_lists: [params, grads, momentum_buffers]
+        wd: Weight decay coefficient
+        momentum: Momentum factor
+        dampening: Dampening for momentum
+        lr: Learning rate
+        nesterov: Whether to use Nesterov momentum
+        first_run: Whether this is the first run (initialize momentum buffer)
+        wd_after_momentum: Whether to apply weight decay after momentum
+        scale: Scale factor for gradients
+    """
     if noop_flag.item() != 0:
         return
 
@@ -246,12 +279,17 @@ def multi_tensor_sgd_torch(
         if grad is None:
             continue
 
-        if weight_decay != 0:
-            grad = grad.add(param, alpha=weight_decay)
+        # Apply scale to gradient
+        if scale != 1.0:
+            grad = grad * scale
+
+        # Apply weight decay before momentum (L2 regularization style)
+        if wd != 0 and not wd_after_momentum:
+            grad = grad.add(param, alpha=wd)
 
         if momentum != 0:
-            if buf is None or buf.numel() == 0:
-                buf = grad.clone().detach()
+            if first_run or buf is None or buf.numel() == 0:
+                buf.copy_(grad)
             else:
                 buf.mul_(momentum).add_(grad, alpha=1 - dampening)
 
@@ -259,6 +297,10 @@ def multi_tensor_sgd_torch(
                 grad = grad.add(buf, alpha=momentum)
             else:
                 grad = buf
+
+        # Apply weight decay after momentum (decoupled style)
+        if wd != 0 and wd_after_momentum:
+            param.add_(param, alpha=-lr * wd)
 
         param.add_(grad, alpha=-lr)
 

--- a/transformer_engine/plugin/core/backends/reference/impl/optimizer.py
+++ b/transformer_engine/plugin/core/backends/reference/impl/optimizer.py
@@ -14,7 +14,6 @@ __all__ = [
     "multi_tensor_compute_scale_and_scale_inv_torch",
 ]
 
-
 def multi_tensor_scale_torch(
     chunk_size: int,
     noop_flag: torch.Tensor,
@@ -33,8 +32,10 @@ def multi_tensor_scale_torch(
         raise ValueError("Output and input tensor lists must have the same length")
 
     for in_tensor, out_tensor in zip(input_tensors, output_tensors):
+        # Check for inf/nan (matches CUDA behavior for AMP gradient scaling)
+        if not torch.isfinite(in_tensor).all():
+            noop_flag.fill_(1)
         out_tensor.copy_(in_tensor * scale)
-
 
 def multi_tensor_l2norm_torch(
     chunk_size: int,
@@ -63,7 +64,10 @@ def multi_tensor_l2norm_torch(
 
     for tensor in tensors:
         norm_sq = torch.sum(tensor.float() ** 2)
-        total_norm_sq += norm_sq
+        # Check for inf/nan (matches CUDA behavior)
+        if not torch.isfinite(norm_sq):
+            noop_flag.fill_(1)
+        total_norm_sq = total_norm_sq + norm_sq
         if per_tensor:
             per_tensor_norms.append(torch.sqrt(norm_sq))
 
@@ -76,7 +80,6 @@ def multi_tensor_l2norm_torch(
 
     return total_norm, per_tensor_result
 
-
 def multi_tensor_adam_torch(
     chunk_size: int,
     noop_flag: torch.Tensor,
@@ -84,12 +87,18 @@ def multi_tensor_adam_torch(
     lr: float,
     beta1: float,
     beta2: float,
-    eps: float,
+    epsilon: float,
     step: int,
     mode: int,
     bias_correction: int,
     weight_decay: float,
 ) -> None:
+    """
+    Adam optimizer implementation matching CUDA exactly.
+
+    mode == 0: L2 regularization (add weight_decay * param to gradient before moment update)
+    mode == 1: AdamW (add weight_decay * param to update after moment computation)
+    """
     if noop_flag.item() != 0:
         return
 
@@ -112,19 +121,43 @@ def multi_tensor_adam_torch(
         if grad is None:
             continue
 
-        if mode == 1 and weight_decay != 0:
-            param.mul_(1 - lr * weight_decay)
+        # Convert to float for computation (matches CUDA's MATH_T = float)
+        g = grad.float()
+        p = param.float()
 
-        exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
+        if mode == 0:  # L2 regularization
+            # Add weight decay to gradient before moment update
+            g = g + weight_decay * p
 
-        exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
+            # Update moments with modified gradient
+            exp_avg.mul_(beta1).add_(g, alpha=1 - beta1)
+            exp_avg_sq.mul_(beta2).addcmul_(g, g, value=1 - beta2)
 
-        corrected_exp_avg = exp_avg / bias_correction1
-        corrected_exp_avg_sq = exp_avg_sq / bias_correction2
+            # Bias correction
+            m_corr = exp_avg / bias_correction1
+            v_corr = exp_avg_sq / bias_correction2
 
-        denom = corrected_exp_avg_sq.sqrt().add_(eps)
-        param.addcdiv_(corrected_exp_avg, denom, value=-lr)
+            # Compute update
+            denom = v_corr.sqrt().add_(epsilon)
+            update = m_corr / denom
 
+            # Update parameter
+            param.add_(update, alpha=-lr)
+        else:  # mode == 1, AdamW (decoupled weight decay)
+            # Update moments with original gradient
+            exp_avg.mul_(beta1).add_(g, alpha=1 - beta1)
+            exp_avg_sq.mul_(beta2).addcmul_(g, g, value=1 - beta2)
+
+            # Bias correction
+            m_corr = exp_avg / bias_correction1
+            v_corr = exp_avg_sq / bias_correction2
+
+            # Compute update with weight decay added (matches CUDA exactly)
+            denom = v_corr.sqrt().add_(epsilon)
+            update = (m_corr / denom) + (weight_decay * p)
+
+            # Update parameter
+            param.add_(update, alpha=-lr)
 
 def multi_tensor_adam_param_remainder_torch(
     chunk_size: int,
@@ -133,7 +166,7 @@ def multi_tensor_adam_param_remainder_torch(
     lr: float,
     beta1: float,
     beta2: float,
-    eps: float,
+    epsilon: float,
     step: int,
     mode: int,
     bias_correction: int,
@@ -142,17 +175,30 @@ def multi_tensor_adam_param_remainder_torch(
     """
     Adam optimizer with parameter remainders for BF16 precision.
 
-    This variant stores BF16 parameters + int16 remainders to reconstruct FP32 master weights.
-    Used when you have BF16 params and need FP32 master params without storing full FP32 copies.
+    This variant stores BF16 parameters + int16 remainders to reconstruct FP32 master weights
+    using bit manipulation, matching the CUDA implementation exactly.
+
+    The CUDA implementation stores:
+    - p: int16 representing the high 16 bits of FP32 (viewed as BF16)
+    - p_remainder: int16 representing the low 16 bits of FP32
+
+    To reconstruct FP32:
+    - If p_remainder < 0, decrement p (undo rounding)
+    - Combine: fp32.int16[1] = p, fp32.int16[0] = p_remainder
+
+    To split FP32 back:
+    - p = fp32.int16[1] (high 16 bits)
+    - p_remainder = fp32.int16[0] (low 16 bits)
+    - If p_remainder < 0, increment p (round up)
 
     Args:
         chunk_size: Chunk size for processing (unused in PyTorch implementation)
         noop_flag: If non-zero, skip computation
-        tensor_lists: [grads, params (bf16), exp_avgs (fp32), exp_avg_sqs (fp32), param_remainders (int16)]
+        tensor_lists: [grads, params (int16/bf16), exp_avgs (fp32), exp_avg_sqs (fp32), param_remainders (int16)]
         lr: Learning rate
         beta1: First moment decay rate
         beta2: Second moment decay rate
-        eps: Epsilon for numerical stability
+        epsilon: Epsilon for numerical stability
         step: Current optimization step
         mode: 0 = L2 regularization, 1 = AdamW (decoupled weight decay)
         bias_correction: Whether to apply bias correction (1 = yes, 0 = no)
@@ -178,92 +224,87 @@ def multi_tensor_adam_param_remainder_torch(
         bias_correction1 = 1.0
         bias_correction2 = 1.0
 
+    is_adamw = (mode == 1)
+
     for grad, param, exp_avg, exp_avg_sq, param_remainder in zip(
         grads, params, exp_avgs, exp_avg_sqs, param_remainders
     ):
-        if grad is None:
-            continue
+        # Convert gradient to float
+        g_float = grad.float()
 
-        # Reconstruct FP32 master weight from BF16 param + int16 remainder
-        # The CUDA implementation uses bit manipulation to combine them
-        # In PyTorch, we approximate this by:
-        # 1. Convert param (bf16) to fp32 - this gives us the high-precision bits
-        # 2. Add the remainder scaled appropriately
-        param_fp32 = param.float()
+        # Reconstruct FP32 master weight from int16 param + int16 remainder using bit manipulation
+        # This matches the CUDA implementation exactly:
+        # 1. If p_remainder < 0, decrement p (undo rounding)
+        # 2. Combine high 16 bits (p) and low 16 bits (p_remainder) into FP32
 
-        # The remainder represents the lower 16 bits lost in BF16 conversion
-        # We need to scale it back to the proper magnitude
-        # BF16 has 16 bits total (1 sign, 8 exponent, 7 mantissa)
-        # The remainder compensates for the lost precision
-        param_master = param_fp32 + param_remainder.float() * (2.0 ** -16)
+        local_p = param.view(torch.int16).clone()
+        local_p_rem = param_remainder.clone()
 
-        # Standard Adam update on FP32 master weight
-        if mode == 0:  # L2 regularization
-            grad_with_decay = grad.float() + weight_decay * param_master
-        else:  # mode == 1, AdamW
-            grad_with_decay = grad.float()
+        # Undo rounding: if remainder < 0, decrement p
+        local_p = torch.where(local_p_rem < 0, local_p - 1, local_p)
 
-        # Update moments
-        exp_avg.mul_(beta1).add_(grad_with_decay, alpha=1 - beta1)
-        exp_avg_sq.mul_(beta2).addcmul_(grad_with_decay, grad_with_decay, value=1 - beta2)
+        # Combine into FP32 using bit shift operations
+        # local_p is high 16 bits, local_p_rem is low 16 bits
+        high_bits = local_p.to(torch.int32) << 16
+        low_bits = local_p_rem.to(torch.int32) & 0xFFFF  # Mask off sign extension
+        param_int32 = high_bits | low_bits
+        param_master = param_int32.view(torch.float32)
+
+        # L2 mode: add weight decay to gradient before updating moments
+        if not is_adamw and weight_decay != 0:
+            g_float = g_float + weight_decay * param_master
+
+        # Update first moment: m = beta1 * m + (1 - beta1) * g
+        exp_avg.mul_(beta1).add_(g_float, alpha=1 - beta1)
+
+        # Update second moment: v = beta2 * v + (1 - beta2) * g^2
+        exp_avg_sq.mul_(beta2).addcmul_(g_float, g_float, value=1 - beta2)
 
         # Apply bias correction
-        corrected_exp_avg = exp_avg / bias_correction1
-        corrected_exp_avg_sq = exp_avg_sq / bias_correction2
+        m_corr = exp_avg / bias_correction1
+        v_corr = exp_avg_sq / bias_correction2
+
+        # Compute denominator: sqrt(v_corr) + epsilon
+        denom = torch.sqrt(v_corr) + epsilon
 
         # Compute update
-        denom = corrected_exp_avg_sq.sqrt().add_(eps)
-        update = corrected_exp_avg / denom
+        update = m_corr / denom
 
-        if mode == 1:  # AdamW: apply weight decay directly
+        # AdamW mode: add decoupled weight decay to update
+        if is_adamw and weight_decay != 0:
             update = update + weight_decay * param_master
 
-        # Update master weight
-        param_master.add_(update, alpha=-lr)
+        # Update master weight: p = p - lr * update
+        param_master = param_master - lr * update
 
-        # Split back into BF16 param + int16 remainder
-        # Convert to BF16 (this is the rounded version)
-        param_bf16 = param_master.to(dtype=param.dtype)
+        # Split FP32 back into int16 param + int16 remainder using bit manipulation
+        # This matches the CUDA implementation exactly:
+        # 1. Extract high 16 bits as p
+        # 2. Extract low 16 bits as p_remainder
+        # 3. If p_remainder < 0, increment p (round up)
 
-        # Compute remainder: difference between FP32 master and BF16 representation
-        # Scale and quantize to int16 range
-        remainder_fp32 = (param_master - param_bf16.float()) * (2.0 ** 16)
-        remainder_int16 = remainder_fp32.round().clamp(-32768, 32767).to(dtype=torch.int16)
+        param_int32 = param_master.view(torch.int32)
+        # Extract low 16 bits (remainder) and high 16 bits (param)
+        new_p_rem = (param_int32 & 0xFFFF).to(torch.int16)
+        new_p = ((param_int32 >> 16) & 0xFFFF).to(torch.int16)
+
+        # Round up: if remainder < 0, increment p
+        new_p = torch.where(new_p_rem < 0, new_p + 1, new_p)
 
         # Write back
-        param.copy_(param_bf16)
-        param_remainder.copy_(remainder_int16)
-
+        param.view(torch.int16).copy_(new_p)
+        param_remainder.copy_(new_p_rem)
 
 def multi_tensor_sgd_torch(
     chunk_size: int,
     noop_flag: torch.Tensor,
     tensor_lists: List[List[torch.Tensor]],
-    wd: float,
+    lr: float,
     momentum: float,
     dampening: float,
-    lr: float,
+    weight_decay: float,
     nesterov: bool,
-    first_run: bool,
-    wd_after_momentum: bool,
-    scale: float,
 ) -> None:
-    """
-    SGD optimizer with momentum.
-
-    Args:
-        chunk_size: Chunk size (unused in PyTorch implementation)
-        noop_flag: If non-zero, skip computation
-        tensor_lists: [params, grads, momentum_buffers]
-        wd: Weight decay coefficient
-        momentum: Momentum factor
-        dampening: Dampening for momentum
-        lr: Learning rate
-        nesterov: Whether to use Nesterov momentum
-        first_run: Whether this is the first run (initialize momentum buffer)
-        wd_after_momentum: Whether to apply weight decay after momentum
-        scale: Scale factor for gradients
-    """
     if noop_flag.item() != 0:
         return
 
@@ -279,17 +320,12 @@ def multi_tensor_sgd_torch(
         if grad is None:
             continue
 
-        # Apply scale to gradient
-        if scale != 1.0:
-            grad = grad * scale
-
-        # Apply weight decay before momentum (L2 regularization style)
-        if wd != 0 and not wd_after_momentum:
-            grad = grad.add(param, alpha=wd)
+        if weight_decay != 0:
+            grad = grad.add(param, alpha=weight_decay)
 
         if momentum != 0:
-            if first_run or buf is None or buf.numel() == 0:
-                buf.copy_(grad)
+            if buf is None or buf.numel() == 0:
+                buf = grad.clone().detach()
             else:
                 buf.mul_(momentum).add_(grad, alpha=1 - dampening)
 
@@ -298,12 +334,7 @@ def multi_tensor_sgd_torch(
             else:
                 grad = buf
 
-        # Apply weight decay after momentum (decoupled style)
-        if wd != 0 and wd_after_momentum:
-            param.add_(param, alpha=-lr * wd)
-
         param.add_(grad, alpha=-lr)
-
 
 def multi_tensor_compute_scale_and_scale_inv_torch(
     chunk_size: int,

--- a/transformer_engine/plugin/core/backends/reference/impl/rmsnorm.py
+++ b/transformer_engine/plugin/core/backends/reference/impl/rmsnorm.py
@@ -43,7 +43,6 @@ def rmsnorm_bwd_torch(
     gamma,
     sm_margin,
     zero_centered_gamma,
-    eps,
 ):
     inv_rms = rsigma.unsqueeze(-1)
 

--- a/transformer_engine/plugin/core/backends/reference/reference.py
+++ b/transformer_engine/plugin/core/backends/reference/reference.py
@@ -75,19 +75,19 @@ class ReferenceBackend(TEFLBackendBase):
     def generic_gemm(
         self,
         A: Any,
-        transa: bool,
+        transA: bool,
         B: Any,
-        transb: bool,
+        transB: bool,
         D: Any,
         quantizer: Any,
-        out_dtype: Optional[DType],
+        output_dtype: Optional[DType],
         bias: Optional[torch.Tensor],
         bias_type: DType,
         gelu: bool,
         gelu_in: Optional[torch.Tensor],
         grad: bool,
         workspace: torch.Tensor,
-        workspaceSize: int,
+        workspace_size: int,
         accumulate: bool,
         use_split_accumulator: bool,
         comm_overlap: Optional[Any] = None,
@@ -98,28 +98,10 @@ class ReferenceBackend(TEFLBackendBase):
         beta: Optional[float] = None,
     ) -> List[Any]:
         return general_gemm_torch(
-            A=A,
-            transA=transa,
-            B=B,
-            transB=transb,
-            D=D,
-            quantizer=quantizer,
-            output_dtype=out_dtype,
-            bias=bias,
-            bias_type=bias_type,
-            gelu=gelu,
-            gelu_in=gelu_in,
-            grad=grad,
-            workspace=workspace,
-            workspace_size=workspaceSize,
-            accumulate=accumulate,
-            use_split_accumulator=use_split_accumulator,
-            comm_overlap=comm_overlap,
-            comm_type=comm_type,
-            extra_output=extra_output,
-            bulk_overlap=bulk_overlap,
-            alpha=alpha,
-            beta=beta,
+            A, transA, B, transB, D, quantizer, output_dtype,
+            bias, bias_type, gelu, gelu_in, grad, workspace, workspace_size,
+            accumulate, use_split_accumulator, comm_overlap, comm_type,
+            extra_output, bulk_overlap, alpha, beta
         )
 
     # GELU and variants
@@ -213,7 +195,7 @@ class ReferenceBackend(TEFLBackendBase):
         grad: torch.Tensor,
         fwd_input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
+    ) -> List[Any]:
         return dbias_dgelu_torch(grad, fwd_input, quantizer)
 
     def dbias_dsilu(
@@ -221,7 +203,7 @@ class ReferenceBackend(TEFLBackendBase):
         grad: torch.Tensor,
         fwd_input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
+    ) -> List[Any]:
         return dbias_dsilu_torch(grad, fwd_input, quantizer)
 
     def dbias_drelu(
@@ -237,7 +219,7 @@ class ReferenceBackend(TEFLBackendBase):
         grad: torch.Tensor,
         fwd_input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
+    ) -> List[Any]:
         return dbias_dqgelu_torch(grad, fwd_input, quantizer)
 
     def dbias_dsrelu(
@@ -245,7 +227,7 @@ class ReferenceBackend(TEFLBackendBase):
         grad: torch.Tensor,
         fwd_input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
+    ) -> List[Any]:
         return dbias_dsrelu_torch(grad, fwd_input, quantizer)
 
     # LayerNorm
@@ -255,12 +237,12 @@ class ReferenceBackend(TEFLBackendBase):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor],
         eps: float,
-        ln_out: Optional[torch.Tensor],
+        ln_out: Any,
         quantizer: Any,
         otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> List[Any]:
         return layernorm_fwd_torch(
             input=input,
             weight=weight,
@@ -280,9 +262,9 @@ class ReferenceBackend(TEFLBackendBase):
         mu: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         return layernorm_bwd_torch(
             dy=dz,
             x=x,
@@ -296,15 +278,15 @@ class ReferenceBackend(TEFLBackendBase):
     # RMSNorm
     def rmsnorm_fwd(
         self,
-        input: torch.Tensor,
-        weight: torch.Tensor,
+        input: Any,
+        weight: Any,
         eps: float,
-        ln_out: Optional[torch.Tensor],
+        ln_out: Any,
         quantizer: Any,
         otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    ) -> List[Any]:
         return rmsnorm_fwd_torch(
             input=input,
             weight=weight,
@@ -322,9 +304,9 @@ class ReferenceBackend(TEFLBackendBase):
         x: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         return rmsnorm_bwd_torch(
             dy=dz,
             x=x,

--- a/transformer_engine/plugin/core/backends/reference/reference.py
+++ b/transformer_engine/plugin/core/backends/reference/reference.py
@@ -3,11 +3,9 @@
 # See LICENSE for license information.
 
 import os
-from typing import Any, Dict, List, Optional, Tuple, Union
-
+from typing import Any, List, Optional, Tuple
 import torch
-
-from ...ops import TEFLBackendBase, FP8TensorMeta, NVTE_Fused_Attn_Backend
+from ...ops import *
 
 from .impl import (
     general_gemm_torch,
@@ -33,6 +31,7 @@ from .impl import (
     multi_tensor_sgd_torch,
 )
 
+
 class ReferenceBackend(TEFLBackendBase):
     @staticmethod
     def check_available() -> bool:
@@ -41,11 +40,7 @@ class ReferenceBackend(TEFLBackendBase):
     def is_available(self) -> bool:
         return True
 
-    def get_flash_attention_class(self):
-        from .flash_attention import FlashAttentionTorch
-        return FlashAttentionTorch
-
-    def get_attention_backend(self, attention_params=None):
+    def get_attention_backend(self, _attention_params=None):
         from packaging.version import Version as PkgVersion
         from ...logger_manager import get_logger
         logger = get_logger()
@@ -79,44 +74,44 @@ class ReferenceBackend(TEFLBackendBase):
 
     def generic_gemm(
         self,
-        A: torch.Tensor,
-        transA: bool,
-        B: torch.Tensor,
-        transB: bool,
-        D: torch.Tensor,
+        A: Any,
+        transa: bool,
+        B: Any,
+        transb: bool,
+        D: Any,
         quantizer: Any,
-        output_dtype: torch.dtype,
+        out_dtype: Optional[DType],
         bias: Optional[torch.Tensor],
-        bias_type: Any,
+        bias_type: DType,
         gelu: bool,
         gelu_in: Optional[torch.Tensor],
         grad: bool,
         workspace: torch.Tensor,
-        workspace_size: int,
+        workspaceSize: int,
         accumulate: bool,
         use_split_accumulator: bool,
         comm_overlap: Optional[Any] = None,
-        comm_type: Optional[Any] = None,
+        comm_type: Optional[CommOverlapType] = None,
         extra_output: Optional[torch.Tensor] = None,
         bulk_overlap: bool = False,
         alpha: float = 1.0,
         beta: Optional[float] = None,
-    ) -> Any:
+    ) -> List[Any]:
         return general_gemm_torch(
             A=A,
-            transA=transA,
+            transA=transa,
             B=B,
-            transB=transB,
+            transB=transb,
             D=D,
             quantizer=quantizer,
-            output_dtype=output_dtype,
+            output_dtype=out_dtype,
             bias=bias,
             bias_type=bias_type,
             gelu=gelu,
             gelu_in=gelu_in,
             grad=grad,
             workspace=workspace,
-            workspace_size=workspace_size,
+            workspace_size=workspaceSize,
             accumulate=accumulate,
             use_split_accumulator=use_split_accumulator,
             comm_overlap=comm_overlap,
@@ -127,18 +122,7 @@ class ReferenceBackend(TEFLBackendBase):
             beta=beta,
         )
 
-    def te_general_grouped_gemm(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("te_general_grouped_gemm - not implemented in reference backend")
-
-    def quantize(self, tensor: torch.Tensor, quantizer: Any, output: Optional[torch.Tensor] = None, noop: Optional[torch.Tensor] = None) -> Any:
-        raise NotImplementedError("quantize - not implemented in reference backend")
-
-    def dequantize(self, input: torch.Tensor, otype: torch.dtype) -> torch.Tensor:
-        raise NotImplementedError("dequantize - not implemented in reference backend")
-
-    def bgrad_quantize(self, input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
-        raise NotImplementedError("bgrad_quantize - not implemented in reference backend")
-
+    # GELU and variants
     def gelu(self, input: torch.Tensor, quantizer: Any) -> Any:
         return gelu_torch(input, quantizer)
 
@@ -151,6 +135,7 @@ class ReferenceBackend(TEFLBackendBase):
     def qgeglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         return qgeglu_torch(input, quantizer)
 
+    # ReLU and variants
     def relu(self, input: torch.Tensor, quantizer: Any) -> Any:
         return relu_torch(input, quantizer)
 
@@ -163,15 +148,23 @@ class ReferenceBackend(TEFLBackendBase):
     def sreglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         return sreglu_torch(input, quantizer)
 
+    # SwiGLU and variants
     def silu(self, input: torch.Tensor, quantizer: Any) -> Any:
         return silu_torch(input, quantizer)
 
     def swiglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         return swiglu_torch(input, quantizer)
 
-    def clamped_swiglu(self, input: torch.Tensor, quantizer: Any, limit: float = 7.0, alpha: float = 1.702) -> Any:
+    def clamped_swiglu(
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+        limit: float = 7.0,
+        alpha: float = 1.702,
+    ) -> Any:
         return clamped_swiglu_torch(input, quantizer, limit, alpha)
 
+    # Backward of GELU and variants
     def dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         return dgelu_torch(grad, fwd_input, quantizer)
 
@@ -184,6 +177,7 @@ class ReferenceBackend(TEFLBackendBase):
     def dqgeglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         return dqgeglu_torch(grad, fwd_input, quantizer)
 
+    # Backward of ReLU and variants
     def drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         return drelu_torch(grad, fwd_input, quantizer)
 
@@ -196,30 +190,65 @@ class ReferenceBackend(TEFLBackendBase):
     def dsreglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         return dsreglu_torch(grad, fwd_input, quantizer)
 
+    # Backward of SiLU and variants
     def dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         return dsilu_torch(grad, fwd_input, quantizer)
 
     def dswiglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         return dswiglu_torch(grad, fwd_input, quantizer)
 
-    def clamped_dswiglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any, limit: float = 7.0, alpha: float = 1.702) -> Any:
+    def clamped_dswiglu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+        limit: float = 7.0,
+        alpha: float = 1.702,
+    ) -> Any:
         return clamped_dswiglu_torch(grad, fwd_input, quantizer, limit, alpha)
 
-    def dbias_dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    # DBias + DAct fusions
+    def dbias_dgelu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Tuple[torch.Tensor, Any]:
         return dbias_dgelu_torch(grad, fwd_input, quantizer)
 
-    def dbias_dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dsilu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Tuple[torch.Tensor, Any]:
         return dbias_dsilu_torch(grad, fwd_input, quantizer)
 
-    def dbias_drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_drelu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Tuple[torch.Tensor, Any]:
         return dbias_drelu_torch(grad, fwd_input, quantizer)
 
-    def dbias_dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dqgelu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Tuple[torch.Tensor, Any]:
         return dbias_dqgelu_torch(grad, fwd_input, quantizer)
 
-    def dbias_dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dsrelu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Tuple[torch.Tensor, Any]:
         return dbias_dsrelu_torch(grad, fwd_input, quantizer)
 
+    # LayerNorm
     def layernorm_fwd(
         self,
         input: torch.Tensor,
@@ -228,7 +257,7 @@ class ReferenceBackend(TEFLBackendBase):
         eps: float,
         ln_out: Optional[torch.Tensor],
         quantizer: Any,
-        otype: torch.dtype,
+        otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -246,7 +275,7 @@ class ReferenceBackend(TEFLBackendBase):
 
     def layernorm_bwd(
         self,
-        dy: torch.Tensor,
+        dz: torch.Tensor,
         x: torch.Tensor,
         mu: torch.Tensor,
         rsigma: torch.Tensor,
@@ -255,7 +284,7 @@ class ReferenceBackend(TEFLBackendBase):
         zero_centered_gamma: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         return layernorm_bwd_torch(
-            dy=dy,
+            dy=dz,
             x=x,
             mu=mu,
             rsigma=rsigma,
@@ -264,6 +293,7 @@ class ReferenceBackend(TEFLBackendBase):
             zero_centered_gamma=zero_centered_gamma,
         )
 
+    # RMSNorm
     def rmsnorm_fwd(
         self,
         input: torch.Tensor,
@@ -271,7 +301,7 @@ class ReferenceBackend(TEFLBackendBase):
         eps: float,
         ln_out: Optional[torch.Tensor],
         quantizer: Any,
-        otype: torch.dtype,
+        otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
@@ -288,153 +318,126 @@ class ReferenceBackend(TEFLBackendBase):
 
     def rmsnorm_bwd(
         self,
-        dy: torch.Tensor,
+        dz: torch.Tensor,
         x: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
         sm_margin: int = 0,
         zero_centered_gamma: bool = False,
-        eps: float = 1e-5,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         return rmsnorm_bwd_torch(
-            dy=dy,
+            dy=dz,
             x=x,
             rsigma=rsigma,
             gamma=gamma,
             sm_margin=sm_margin,
             zero_centered_gamma=zero_centered_gamma,
-            eps=eps,
         )
 
-    def rmsnorm_bwd_add(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("rmsnorm_bwd_add - not implemented in reference backend")
-
-    def multi_tensor_quantize(self, tensor_list: List[torch.Tensor], quantizer_list: List[Any]) -> List[Any]:
-        raise NotImplementedError("multi_tensor_quantize - not implemented in reference backend")
-
-    def split_quantize(self, tensor: torch.Tensor, split_sections: List[int], quantizer_list: List[Any]) -> List[Any]:
-        raise NotImplementedError("split_quantize - not implemented in reference backend")
-
-    def moe_permute_fwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("moe_permute_fwd - not implemented in reference backend")
-
-    def moe_permute_bwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("moe_permute_bwd - not implemented in reference backend")
-
-    def moe_unpermute_fwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("moe_unpermute_fwd - not implemented in reference backend")
-
-    def moe_unpermute_bwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("moe_unpermute_bwd - not implemented in reference backend")
-
-    def scaled_softmax_forward(self, input: torch.Tensor, scale: float) -> torch.Tensor:
+    # Softmax functions
+    def scaled_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale: float,
+    ) -> torch.Tensor:
         return scaled_softmax_forward_torch(input, scale)
 
-    def scaled_softmax_backward(self, output_grad: torch.Tensor, softmax_output: torch.Tensor, scale: float) -> torch.Tensor:
-        return scaled_softmax_backward_torch(output_grad, softmax_output, scale)
+    def scaled_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        return scaled_softmax_backward_torch(output_grad_, softmax_results_, scale_factor)
 
-    def scaled_masked_softmax_forward(self, input: torch.Tensor, mask: torch.Tensor, scale: float) -> torch.Tensor:
-        return scaled_masked_softmax_forward_torch(input, mask, scale)
+    def scaled_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        mask: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        return scaled_masked_softmax_forward_torch(input, mask, scale_factor)
 
-    def scaled_masked_softmax_backward(self, output_grad: torch.Tensor, softmax_output: torch.Tensor, scale: float) -> torch.Tensor:
-        return scaled_masked_softmax_backward_torch(output_grad, softmax_output, scale)
+    def scaled_masked_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        return scaled_masked_softmax_backward_torch(output_grad_, softmax_results_, scale_factor)
 
-    def scaled_upper_triang_masked_softmax_forward(self, input: torch.Tensor, scale: float) -> torch.Tensor:
-        return scaled_upper_triang_masked_softmax_forward_torch(input, scale)
+    def scaled_upper_triang_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        return scaled_upper_triang_masked_softmax_forward_torch(input, scale_factor)
 
-    def scaled_upper_triang_masked_softmax_backward(self, output_grad: torch.Tensor, softmax_output: torch.Tensor, scale: float) -> torch.Tensor:
-        return scaled_upper_triang_masked_softmax_backward_torch(output_grad, softmax_output, scale)
+    def scaled_upper_triang_masked_softmax_backward(
+        self,
+        output_grads_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        return scaled_upper_triang_masked_softmax_backward_torch(output_grads_, softmax_results_, scale_factor)
 
-    def scaled_aligned_causal_masked_softmax_forward(self, input: torch.Tensor, scale: float) -> torch.Tensor:
-        return scaled_aligned_causal_masked_softmax_forward_torch(input, scale)
+    def scaled_aligned_causal_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        return scaled_aligned_causal_masked_softmax_forward_torch(input, scale_factor)
 
-    def scaled_aligned_causal_masked_softmax_backward(self, output_grad: torch.Tensor, softmax_output: torch.Tensor, scale: float) -> torch.Tensor:
-        return scaled_aligned_causal_masked_softmax_backward_torch(output_grad, softmax_output, scale)
+    def scaled_aligned_causal_masked_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        return scaled_aligned_causal_masked_softmax_backward_torch(output_grad_, softmax_results_, scale_factor)
 
-    def get_fused_attn_backend(self, *args, **kwargs) -> int:
+    # Fused attention backend
+    def get_fused_attn_backend(
+        self,
+        _is_training: bool,
+        _q_dtype: DType,
+        _kv_dtype: DType,
+        _qkv_layout: NVTE_QKV_Layout,
+        _bias_type: NVTE_Bias_Type,
+        _attn_mask_type: NVTE_Mask_Type,
+        _softmax_type: NVTE_Softmax_Type,
+        _p_dropout: float,
+        _num_attn_heads: int,
+        _num_gqa_groups: int,
+        _max_seqlen_q: int,
+        _max_seqlen_kv: int,
+        _head_dim_qk: int,
+        _head_dim_v: int,
+        _window_size_left: int,
+        _window_size_right: int,
+        _return_max_logit: bool,
+    ) -> NVTE_Fused_Attn_Backend:
         return NVTE_Fused_Attn_Backend.NVTE_No_Backend
 
-    def fused_attn_fwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_attn_fwd - not implemented in reference backend")
-
-    def fused_attn_bwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_attn_bwd - not implemented in reference backend")
-
-    def fa_prepare_fwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fa_prepare_fwd - not implemented in reference backend")
-
-    def fa_prepare_bwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fa_prepare_bwd - not implemented in reference backend")
-
-    def copy_to_kv_cache(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("copy_to_kv_cache - not implemented in reference backend")
-
-    def convert_thd_to_bshd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("convert_thd_to_bshd - not implemented in reference backend")
-
-    def convert_bshd_to_thd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("convert_bshd_to_thd - not implemented in reference backend")
-
-    def fused_rope_forward(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_rope_forward - not implemented in reference backend")
-
-    def fused_rope_backward(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_rope_backward - not implemented in reference backend")
-
-    def fused_qkv_rope_forward(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_qkv_rope_forward - not implemented in reference backend")
-
-    def fused_qkv_rope_backward(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_qkv_rope_backward - not implemented in reference backend")
-
-    def fused_topk_with_score_function_fwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_topk_with_score_function_fwd - not implemented in reference backend")
-
-    def fused_topk_with_score_function_bwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_topk_with_score_function_bwd - not implemented in reference backend")
-
-    def fused_score_for_moe_aux_loss_fwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_score_for_moe_aux_loss_fwd - not implemented in reference backend")
-
-    def fused_score_for_moe_aux_loss_bwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_score_for_moe_aux_loss_bwd - not implemented in reference backend")
-
-    def fused_moe_aux_loss_fwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_moe_aux_loss_fwd - not implemented in reference backend")
-
-    def fused_moe_aux_loss_bwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_moe_aux_loss_bwd - not implemented in reference backend")
-
-    def dropout_fwd(self, input: torch.Tensor, dropout_probability: float, out: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, torch.Tensor]:
+    # Dropout
+    def dropout_fwd(
+        self,
+        input: torch.Tensor,
+        dropout_probability: float,
+        out: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         return dropout_fwd_torch(input, dropout_probability, out)
 
-    def dropout_bwd(self, grad_output: torch.Tensor, mask: torch.Tensor, dropout_probability: float, grad_input: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def dropout_bwd(
+        self,
+        grad_output: torch.Tensor,
+        mask: torch.Tensor,
+        dropout_probability: float,
+        grad_input: Optional[torch.Tensor],
+    ) -> torch.Tensor:
         return dropout_bwd_torch(grad_output, mask, dropout_probability, grad_input)
 
-    def fp8_transpose(self, input: torch.Tensor, dtype: Any, *, out: torch.Tensor) -> None:
-        raise NotImplementedError("fp8_transpose - not implemented in reference backend")
-
-    def swap_first_dims(self, tensor: torch.Tensor, *, out: torch.Tensor) -> None:
-        raise NotImplementedError("swap_first_dims - not implemented in reference backend")
-
-    def compute_amax(self, input: torch.Tensor, amax: torch.Tensor) -> None:
-        raise NotImplementedError("compute_amax - not implemented in reference backend")
-
-    def fused_amax_and_scale_update_after_reduction(self, *args, **kwargs) -> None:
-        raise NotImplementedError("fused_amax_and_scale_update_after_reduction - not implemented in reference backend")
-
-    def fp8_block_scaling_compute_partial_amax(self, *args, **kwargs) -> None:
-        raise NotImplementedError("fp8_block_scaling_compute_partial_amax - not implemented in reference backend")
-
-    def fp8_block_scaling_partial_cast(self, *args, **kwargs) -> None:
-        raise NotImplementedError("fp8_block_scaling_partial_cast - not implemented in reference backend")
-
-    def fused_multi_row_padding(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_multi_row_padding - not implemented in reference backend")
-
-    def fused_multi_row_unpadding(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_multi_row_unpadding - not implemented in reference backend")
-
+    # Misc
     def get_cublasLt_version(self) -> int:
         return 0
 
@@ -444,100 +447,101 @@ class ReferenceBackend(TEFLBackendBase):
     def get_num_cublas_streams(self) -> int:
         return 0
 
-    def thd_read_half_tensor(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("thd_read_half_tensor - not implemented in reference backend")
-
-    def thd_second_half_lse_correction(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("thd_second_half_lse_correction - not implemented in reference backend")
-
-    def thd_read_second_half_lse(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("thd_read_second_half_lse - not implemented in reference backend")
-
-    def thd_out_correction(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("thd_out_correction - not implemented in reference backend")
-
-    def thd_grad_correction(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("thd_grad_correction - not implemented in reference backend")
-
-    def thd_get_partitioned_indices(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("thd_get_partitioned_indices - not implemented in reference backend")
-
-    def init_nvshmem_backend(self, *args, **kwargs) -> None:
-        raise NotImplementedError("init_nvshmem_backend - not implemented in reference backend")
-
-    def create_nvshmem_tensor(self, *args, **kwargs) -> torch.Tensor:
-        raise NotImplementedError("create_nvshmem_tensor - not implemented in reference backend")
-
-    def nvshmem_send_on_current_stream(self, *args, **kwargs) -> None:
-        raise NotImplementedError("nvshmem_send_on_current_stream - not implemented in reference backend")
-
-    def nvshmem_wait_on_current_stream(self, *args, **kwargs) -> None:
-        raise NotImplementedError("nvshmem_wait_on_current_stream - not implemented in reference backend")
-
-    def nvshmem_finalize(self) -> None:
-        raise NotImplementedError("nvshmem_finalize - not implemented in reference backend")
-
-    def multi_tensor_scale(self, chunk_size: int, noop_flag: torch.Tensor, tensor_lists: List[List[torch.Tensor]], scale: float) -> None:
+    # Multi-tensor functions
+    def multi_tensor_scale(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        scale: float,
+    ) -> None:
         return multi_tensor_scale_torch(chunk_size, noop_flag, tensor_lists, scale)
 
-    def multi_tensor_l2norm(self, chunk_size: int, noop_flag: torch.Tensor, tensor_lists: List[List[torch.Tensor]], per_tensor: bool = False) -> Union[torch.Tensor, List[torch.Tensor]]:
+    def multi_tensor_l2norm(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        per_tensor: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         return multi_tensor_l2norm_torch(chunk_size, noop_flag, tensor_lists, per_tensor)
 
-    def multi_tensor_unscale_l2norm(self, chunk_size: int, noop_flag: torch.Tensor, tensor_lists: List[List[torch.Tensor]], scale: torch.Tensor, per_tensor: bool = False) -> Union[torch.Tensor, List[torch.Tensor]]:
-        """Compute L2 norm after unscaling.
-
-        Note: scale parameter is actually inv_scale (1/loss_scale).
-        Unscaling means multiplying by inv_scale (= dividing by loss_scale).
-        """
+    def multi_tensor_unscale_l2norm(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        inv_scale: torch.Tensor,
+        per_tensor: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         if noop_flag.item() != 0:
-            if per_tensor:
-                return [torch.tensor(0.0, device=t.device) for t in tensor_lists[0]]
-            else:
-                return torch.tensor(0.0, device=tensor_lists[0][0].device)
+            device = tensor_lists[0][0].device if tensor_lists and tensor_lists[0] else 'cpu'
+            return torch.tensor(0.0, device=device), torch.tensor(0.0, device=device)
 
-        # Multiply by inv_scale (scale parameter is actually inverse scale)
+        # Multiply by inv_scale
         unscaled_tensors = []
         for tensor in tensor_lists[0]:
-            unscaled_tensors.append(tensor * scale.item())
+            unscaled_tensors.append(tensor * inv_scale.item())
 
         return multi_tensor_l2norm_torch(chunk_size, noop_flag, [unscaled_tensors], per_tensor)
 
-    def multi_tensor_adam(self, *args, **kwargs):
-        if not args and not kwargs:
-            return multi_tensor_adam_torch
-        return multi_tensor_adam_torch(*args, **kwargs)
+    def multi_tensor_adam(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
+        return multi_tensor_adam_torch(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon, step, mode, bias_correction, weight_decay
+        )
 
-    def multi_tensor_adam_param_remainder(self, *args, **kwargs):
-        if not args and not kwargs:
-            return multi_tensor_adam_param_remainder_torch
-        return multi_tensor_adam_param_remainder_torch(*args, **kwargs)
+    def multi_tensor_adam_param_remainder(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
+        return multi_tensor_adam_param_remainder_torch(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon, step, mode, bias_correction, weight_decay
+        )
 
-    def multi_tensor_adam_fp8(self, *args, **kwargs) -> None:
-        raise NotImplementedError("multi_tensor_adam_fp8 - not implemented in reference backend")
+    def multi_tensor_sgd(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        wd: float,
+        momentum: float,
+        dampening: float,
+        lr: float,
+        nesterov: bool,
+        first_run: bool,
+        wd_after_momentum: bool,
+        scale: float,
+    ) -> None:
+        return multi_tensor_sgd_torch(
+            chunk_size, noop_flag, tensor_lists,
+            wd, momentum, dampening, lr, nesterov, first_run, wd_after_momentum, scale
+        )
 
-    def multi_tensor_adam_capturable(self, *args, **kwargs) -> None:
-        raise NotImplementedError("multi_tensor_adam_capturable - not implemented in reference backend")
-
-    def multi_tensor_adam_capturable_master(self, *args, **kwargs) -> None:
-        raise NotImplementedError("multi_tensor_adam_capturable_master - not implemented in reference backend")
-
-    def multi_tensor_sgd(self, *args, **kwargs) -> None:
-        return multi_tensor_sgd_torch(*args, **kwargs)
-
-    def multi_tensor_compute_scale_and_scale_inv(self, *args, **kwargs) -> None:
-        raise NotImplementedError("multi_tensor_compute_scale_and_scale_inv - not implemented in reference backend")
-
-    def bulk_overlap_ag_with_external_gemm(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("bulk_overlap_ag_with_external_gemm - not implemented in reference backend")
-
-    def create_fp8_tensor_meta(self) -> FP8TensorMeta:
-        return FP8TensorMeta()
-
-    def create_comm_overlap_helper(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("create_comm_overlap_helper - not implemented in reference backend")
-
-    def create_comm_overlap(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("create_comm_overlap - not implemented in reference backend")
-
-    def create_comm_overlap_p2p(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("create_comm_overlap_p2p - not implemented in reference backend")
+    def get_flash_attention_class(self):
+        from .flash_attention import FlashAttentionTorch
+        return FlashAttentionTorch

--- a/transformer_engine/plugin/core/backends/reference/register_ops.py
+++ b/transformer_engine/plugin/core/backends/reference/register_ops.py
@@ -43,20 +43,11 @@ def register_builtins(registry) -> None:
         # Normalization
         OpImpl(op_name="rmsnorm_fwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.rmsnorm_fwd, is_avail), vendor=None, priority=50),
         OpImpl(op_name="rmsnorm_bwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.rmsnorm_bwd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="rmsnorm_bwd_add", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.rmsnorm_bwd_add, is_avail), vendor=None, priority=50),
         OpImpl(op_name="layernorm_fwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.layernorm_fwd, is_avail), vendor=None, priority=50),
         OpImpl(op_name="layernorm_bwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.layernorm_bwd, is_avail), vendor=None, priority=50),
 
         # GEMM
         OpImpl(op_name="generic_gemm", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.generic_gemm, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="te_general_grouped_gemm", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.te_general_grouped_gemm, is_avail), vendor=None, priority=50),
-
-        # Quantization
-        OpImpl(op_name="quantize", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.quantize, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="dequantize", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.dequantize, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="bgrad_quantize", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.bgrad_quantize, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="multi_tensor_quantize", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.multi_tensor_quantize, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="split_quantize", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.split_quantize, is_avail), vendor=None, priority=50),
 
         # Activations - Forward
         OpImpl(op_name="gelu", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.gelu, is_avail), vendor=None, priority=50),
@@ -101,75 +92,17 @@ def register_builtins(registry) -> None:
         OpImpl(op_name="scaled_aligned_causal_masked_softmax_forward", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.scaled_aligned_causal_masked_softmax_forward, is_avail), vendor=None, priority=50),
         OpImpl(op_name="scaled_aligned_causal_masked_softmax_backward", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.scaled_aligned_causal_masked_softmax_backward, is_avail), vendor=None, priority=50),
 
-        # MOE operations
-        OpImpl(op_name="moe_permute_fwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.moe_permute_fwd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="moe_permute_bwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.moe_permute_bwd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="moe_unpermute_fwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.moe_unpermute_fwd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="moe_unpermute_bwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.moe_unpermute_bwd, is_avail), vendor=None, priority=50),
-
-        # Fused attention
+        # Fused attention backend getter
         OpImpl(op_name="get_fused_attn_backend", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.get_fused_attn_backend, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fused_attn_fwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_attn_fwd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fused_attn_bwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_attn_bwd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fa_prepare_fwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fa_prepare_fwd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fa_prepare_bwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fa_prepare_bwd, is_avail), vendor=None, priority=50),
-
-        # KV cache
-        OpImpl(op_name="copy_to_kv_cache", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.copy_to_kv_cache, is_avail), vendor=None, priority=50),
-
-        # Tensor format conversions
-        OpImpl(op_name="convert_thd_to_bshd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.convert_thd_to_bshd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="convert_bshd_to_thd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.convert_bshd_to_thd, is_avail), vendor=None, priority=50),
-
-        # RoPE (Rotary Position Embedding)
-        OpImpl(op_name="fused_rope_forward", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_rope_forward, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fused_rope_backward", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_rope_backward, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fused_qkv_rope_forward", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_qkv_rope_forward, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fused_qkv_rope_backward", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_qkv_rope_backward, is_avail), vendor=None, priority=50),
-
-        # TopK and MOE aux loss
-        OpImpl(op_name="fused_topk_with_score_function_fwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_topk_with_score_function_fwd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fused_topk_with_score_function_bwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_topk_with_score_function_bwd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fused_score_for_moe_aux_loss_fwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_score_for_moe_aux_loss_fwd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fused_score_for_moe_aux_loss_bwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_score_for_moe_aux_loss_bwd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fused_moe_aux_loss_fwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_moe_aux_loss_fwd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fused_moe_aux_loss_bwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_moe_aux_loss_bwd, is_avail), vendor=None, priority=50),
 
         # Dropout
         OpImpl(op_name="dropout_fwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.dropout_fwd, is_avail), vendor=None, priority=50),
         OpImpl(op_name="dropout_bwd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.dropout_bwd, is_avail), vendor=None, priority=50),
 
-        # FP8 operations
-        OpImpl(op_name="fp8_transpose", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fp8_transpose, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="swap_first_dims", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.swap_first_dims, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="compute_amax", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.compute_amax, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fused_amax_and_scale_update_after_reduction", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_amax_and_scale_update_after_reduction, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fp8_block_scaling_compute_partial_amax", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fp8_block_scaling_compute_partial_amax, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fp8_block_scaling_partial_cast", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fp8_block_scaling_partial_cast, is_avail), vendor=None, priority=50),
-
-        # Padding operations
-        OpImpl(op_name="fused_multi_row_padding", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_multi_row_padding, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="fused_multi_row_unpadding", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.fused_multi_row_unpadding, is_avail), vendor=None, priority=50),
-
         # Library version getters
         OpImpl(op_name="get_cublasLt_version", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.get_cublasLt_version, is_avail), vendor=None, priority=50),
         OpImpl(op_name="get_cudnn_version", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.get_cudnn_version, is_avail), vendor=None, priority=50),
         OpImpl(op_name="get_num_cublas_streams", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.get_num_cublas_streams, is_avail), vendor=None, priority=50),
-
-        # THD (Tensor, Hidden, Dimension) operations
-        OpImpl(op_name="thd_read_half_tensor", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.thd_read_half_tensor, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="thd_second_half_lse_correction", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.thd_second_half_lse_correction, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="thd_read_second_half_lse", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.thd_read_second_half_lse, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="thd_out_correction", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.thd_out_correction, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="thd_grad_correction", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.thd_grad_correction, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="thd_get_partitioned_indices", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.thd_get_partitioned_indices, is_avail), vendor=None, priority=50),
-
-        # NVSHMEM operations
-        OpImpl(op_name="init_nvshmem_backend", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.init_nvshmem_backend, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="create_nvshmem_tensor", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.create_nvshmem_tensor, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="nvshmem_send_on_current_stream", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.nvshmem_send_on_current_stream, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="nvshmem_wait_on_current_stream", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.nvshmem_wait_on_current_stream, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="nvshmem_finalize", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.nvshmem_finalize, is_avail), vendor=None, priority=50),
 
         # Multi-tensor optimizer operations
         OpImpl(op_name="multi_tensor_scale", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.multi_tensor_scale, is_avail), vendor=None, priority=50),
@@ -177,18 +110,7 @@ def register_builtins(registry) -> None:
         OpImpl(op_name="multi_tensor_unscale_l2norm", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.multi_tensor_unscale_l2norm, is_avail), vendor=None, priority=50),
         OpImpl(op_name="multi_tensor_adam", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.multi_tensor_adam, is_avail), vendor=None, priority=50),
         OpImpl(op_name="multi_tensor_adam_param_remainder", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.multi_tensor_adam_param_remainder, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="multi_tensor_adam_fp8", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.multi_tensor_adam_fp8, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="multi_tensor_adam_capturable", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.multi_tensor_adam_capturable, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="multi_tensor_adam_capturable_master", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.multi_tensor_adam_capturable_master, is_avail), vendor=None, priority=50),
         OpImpl(op_name="multi_tensor_sgd", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.multi_tensor_sgd, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="multi_tensor_compute_scale_and_scale_inv", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.multi_tensor_compute_scale_and_scale_inv, is_avail), vendor=None, priority=50),
-
-        # Communication overlap operations
-        OpImpl(op_name="bulk_overlap_ag_with_external_gemm", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.bulk_overlap_ag_with_external_gemm, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="create_fp8_tensor_meta", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.create_fp8_tensor_meta, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="create_comm_overlap_helper", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.create_comm_overlap_helper, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="create_comm_overlap", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.create_comm_overlap, is_avail), vendor=None, priority=50),
-        OpImpl(op_name="create_comm_overlap_p2p", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.create_comm_overlap_p2p, is_avail), vendor=None, priority=50),
 
         # FlashAttention class getter
         OpImpl(op_name="get_flash_attention_class", impl_id="reference.torch", kind=BackendImplKind.REFERENCE, fn=_bind_is_available(backend.get_flash_attention_class, is_avail), vendor=None, priority=50),

--- a/transformer_engine/plugin/core/backends/vendor/cuda/cuda.py
+++ b/transformer_engine/plugin/core/backends/vendor/cuda/cuda.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 
-from ....ops import TEFLBackendBase, FP8TensorMeta
+from ....ops import *
 
 def _load_cuda_libs():
     import ctypes
@@ -115,70 +115,6 @@ def _get_tex():
     import transformer_engine_torch_nv
     return transformer_engine_torch_nv
 
-def _torch_dtype_to_te_dtype(torch_dtype, tex_module):
-    if torch_dtype is None:
-        return None
-
-    NativeDType = tex_module.DType
-    if type(torch_dtype).__name__ == 'DType' and type(torch_dtype).__module__ == 'transformer_engine_torch_nv':
-        return torch_dtype
-
-    if hasattr(torch_dtype, 'name') and hasattr(torch_dtype, 'value'):
-        from transformer_engine.plugin.core.ops import DType as PyDType
-        if isinstance(torch_dtype, PyDType):
-            dtype_name = torch_dtype.name
-            if hasattr(NativeDType, dtype_name):
-                return getattr(NativeDType, dtype_name)
-
-    dtype_map = {
-        torch.float32: NativeDType.kFloat32,
-        torch.float16: NativeDType.kFloat16,
-        torch.bfloat16: NativeDType.kBFloat16,
-        torch.int32: NativeDType.kInt32,
-        torch.uint8: NativeDType.kByte,
-    }
-
-    if hasattr(torch, 'float8_e4m3fn'):
-        dtype_map[torch.float8_e4m3fn] = NativeDType.kFloat8E4M3
-    if hasattr(torch, 'float8_e5m2'):
-        dtype_map[torch.float8_e5m2] = NativeDType.kFloat8E5M2
-
-    return dtype_map.get(torch_dtype, torch_dtype)
-
-def _convert_dtype_params(func):
-    import functools
-    import inspect
-    import os
-
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        dtype_params = ['otype', 'output_dtype', 'bias_type']
-
-        from transformer_engine.plugin.core.ops import DType as PyDType
-
-        def needs_conversion(val):
-            return isinstance(val, torch.dtype) or isinstance(val, PyDType)
-
-        for param_name in dtype_params:
-            if param_name in kwargs:
-                value = kwargs[param_name]
-                if needs_conversion(value):
-                    converted = self._to_te_dtype(value)
-                    kwargs[param_name] = converted
-
-        sig = inspect.signature(func)
-        param_names = list(sig.parameters.keys())[1:]
-
-        args_list = list(args)
-        for i, (param_name, arg_value) in enumerate(zip(param_names, args_list)):
-            if param_name in dtype_params and needs_conversion(arg_value):
-                converted = self._to_te_dtype(arg_value)
-                args_list[i] = converted
-
-        return func(self, *args_list, **kwargs)
-
-    return wrapper
-
 class CUDABackend(TEFLBackendBase):
     @staticmethod
     def check_available() -> bool:
@@ -192,15 +128,8 @@ class CUDABackend(TEFLBackendBase):
             self._tex = _get_tex()
         return self._tex
 
-    def _to_te_dtype(self, torch_dtype):
-        return _torch_dtype_to_te_dtype(torch_dtype, self._get_tex())
-
     def is_available(self) -> bool:
         return _check_cuda_available()
-
-    def get_flash_attention_class(self):
-        from .flash_attention import FlashAttentionCUDA
-        return FlashAttentionCUDA
 
     def get_attention_backend(self, attention_params=None):
         """
@@ -214,6 +143,7 @@ class CUDABackend(TEFLBackendBase):
         from transformer_engine.pytorch.attention.dot_product_attention import utils as dpa_utils
         return dpa_utils._original_get_attention_backend(attention_params)
 
+##### transformer_engine/pytorch/csrc/extensions/pybind.cpp #####
     def quantize(
         self,
         tensor: torch.Tensor,
@@ -224,98 +154,89 @@ class CUDABackend(TEFLBackendBase):
         tex = self._get_tex()
         return tex.quantize(tensor, quantizer, output, noop)
 
-    @_convert_dtype_params
     def dequantize(
         self,
-        input: torch.Tensor,
-        otype: torch.dtype,
-    ) -> torch.Tensor:
+        input: Any,
+        otype: DType,
+    ) -> Any:
         tex = self._get_tex()
+        otype = tex.DType(int(otype)) if otype is not None else None
         return tex.dequantize(input, otype)
 
     def bgrad_quantize(
         self,
         input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
         return tex.bgrad_quantize(input, quantizer)
 
-    @_convert_dtype_params
     def generic_gemm(
         self,
-        A: torch.Tensor,
-        transA: bool,
-        B: torch.Tensor,
-        transB: bool,
-        D: torch.Tensor,
+        A: Any,
+        transa: bool,
+        B: Any,
+        transb: bool,
+        D: Any,
         quantizer: Any,
-        output_dtype: torch.dtype,
+        out_dtype: Optional[DType],
         bias: Optional[torch.Tensor],
-        bias_type: Any,
+        bias_type: DType,
         gelu: bool,
         gelu_in: Optional[torch.Tensor],
         grad: bool,
         workspace: torch.Tensor,
-        workspace_size: int,
+        workspaceSize: int,
         accumulate: bool,
         use_split_accumulator: bool,
         comm_overlap: Optional[Any] = None,
-        comm_type: Optional[Any] = None,
+        comm_type: Optional[CommOverlapType] = None,
         extra_output: Optional[torch.Tensor] = None,
         bulk_overlap: bool = False,
         alpha: float = 1.0,
         beta: Optional[float] = None,
-    ) -> Any:
+    ) -> List[Any]:
         tex = self._get_tex()
-
-        if bias_type is None:
-            bias_type = self._to_te_dtype(torch.bfloat16)
-
+        
+        bias_type = tex.DType(int(bias_type)) if bias_type is not None else None
+        comm_type = tex.CommOverlapType(int(comm_type)) if comm_type is not None else None
+        out_dtype = tex.DType(int(out_dtype)) if out_dtype is not None else None
         return tex.generic_gemm(
-            A, transA, B, transB, D, quantizer, output_dtype,
-            bias, bias_type, gelu, gelu_in, grad, workspace, workspace_size,
+            A, transa, B, transb, D, quantizer, out_dtype,
+            bias, bias_type, gelu, gelu_in, grad, workspace, workspaceSize,
             accumulate, use_split_accumulator, comm_overlap, comm_type,
             extra_output, bulk_overlap, alpha, beta
         )
-
-    def te_general_grouped_gemm(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.te_general_grouped_gemm(*args, **kwargs)
-
+    # GELU and variants #
     def gelu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.gelu(input, quantizer)
-
     def geglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.geglu(input, quantizer)
     def qgelu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.qgelu(input, quantizer)
-
     def qgeglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.qgeglu(input, quantizer)
+    # ReLU and variants #
     def relu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.relu(input, quantizer)
-
     def reglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.reglu(input, quantizer)
     def srelu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.srelu(input, quantizer)
-
     def sreglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.sreglu(input, quantizer)
-
+    # SwiGLU and variants #
     def silu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.silu(input, quantizer)
-
     def swiglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.swiglu(input, quantizer)
@@ -328,42 +249,39 @@ class CUDABackend(TEFLBackendBase):
     ) -> Any:
         tex = self._get_tex()
         return tex.clamped_swiglu(input, quantizer, limit, alpha)
-
+    # Backward of GELU and variants #
     def dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dgelu(grad, fwd_input, quantizer)
     def dgeglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dgeglu(grad, fwd_input, quantizer)
-
     def dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dqgelu(grad, fwd_input, quantizer)
     def dqgeglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dqgeglu(grad, fwd_input, quantizer)
-
+    # Backward of ReLU and variants #
     def drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.drelu(grad, fwd_input, quantizer)
     def dreglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dreglu(grad, fwd_input, quantizer)
-
     def dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dsrelu(grad, fwd_input, quantizer)
     def dsreglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dsreglu(grad, fwd_input, quantizer)
-
+    # Backward of SiLU and variants #
     def dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dsilu(grad, fwd_input, quantizer)
     def dswiglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dswiglu(grad, fwd_input, quantizer)
-
     def clamped_dswiglu(
         self,
         grad: torch.Tensor,
@@ -374,28 +292,137 @@ class CUDABackend(TEFLBackendBase):
     ) -> Any:
         tex = self._get_tex()
         return tex.clamped_dswiglu(grad, fwd_input, quantizer, limit, alpha)
-
+    # DBias + DAct fusions #
     def dbias_dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dgelu(grad, fwd_input, quantizer)
-
     def dbias_dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dsilu(grad, fwd_input, quantizer)
-
     def dbias_drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_drelu(grad, fwd_input, quantizer)
-
     def dbias_dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dqgelu(grad, fwd_input, quantizer)
-
     def dbias_dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dsrelu(grad, fwd_input, quantizer)
-
-    @_convert_dtype_params
+    # Permutation functions                                                                                                                                                                                                                                                                                             
+    def moe_permute_fwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        indices: torch.Tensor,
+        num_out_tokens: int,
+        workspace: List[torch.Tensor],
+        max_expanded_token_num: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, List[torch.Tensor]]:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_permute_fwd(input, dtype,indices,num_out_tokens,workspace,max_expanded_token_num)
+    def moe_permute_bwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+        num_tokens: int,
+        topK: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_permute_bwd(input,dtype,row_id_map,prob,num_tokens,topK)
+    def moe_unpermute_fwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+        num_tokens: int,
+        topK: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_unpermute_fwd(input,dtype,row_id_map,prob,num_tokens,topK)
+    def moe_unpermute_bwd(
+        self,
+        input_bwd: torch.Tensor,
+        input_fwd: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_unpermute_bwd(input_bwd,input_fwd,dtype,row_id_map,prob)
+    # Softmax functions
+    def scaled_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_softmax_forward(input, scale)
+    def scaled_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_softmax_backward(output_grad_, softmax_results_, scale_factor)
+    def scaled_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        mask: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_masked_softmax_forward(input, mask, scale_factor)
+    def scaled_masked_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_masked_softmax_backward(output_grad_, softmax_results_, scale_factor)
+    def scaled_upper_triang_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_upper_triang_masked_softmax_forward(input, scale_factor)
+    def scaled_upper_triang_masked_softmax_backward(
+        self,
+        output_grads_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_upper_triang_masked_softmax_backward(
+            output_grads_, softmax_results_, scale_factor
+        )
+    def scaled_aligned_causal_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_aligned_causal_masked_softmax_forward(input, scale_factor)
+    def scaled_aligned_causal_masked_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_aligned_causal_masked_softmax_backward(
+            output_grad_, softmax_results_, scale_factor
+        )
+    # Other granular functions
     def layernorm_fwd(
         self,
         input: torch.Tensor,
@@ -404,27 +431,18 @@ class CUDABackend(TEFLBackendBase):
         eps: float,
         ln_out: Optional[torch.Tensor],
         quantizer: Any,
-        otype: torch.dtype,
+        otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = input.shape
-        if input.ndim > 2:
-            input = input.view(-1, input.shape[-1])
-
-        y, mu, rsigma = tex.layernorm_fwd(
+        otype = tex.DType(int(otype)) if otype is not None else None
+        return tex.layernorm_fwd(
             input, weight, bias, eps, ln_out, quantizer, otype, sm_margin, zero_centered_gamma
         )
-
-        if len(orig_shape) > 2:
-            y = y.view(*orig_shape)
-        return y, mu, rsigma
-
     def layernorm_bwd(
         self,
-        dy: torch.Tensor,
+        dz: torch.Tensor,
         x: torch.Tensor,
         mu: torch.Tensor,
         rsigma: torch.Tensor,
@@ -433,19 +451,9 @@ class CUDABackend(TEFLBackendBase):
         zero_centered_gamma: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = dy.shape
-        if dy.ndim > 2:
-            dy = dy.view(-1, dy.shape[-1])
-            x = x.view(-1, x.shape[-1])
-
-        dx, dgamma, dbeta = tex.layernorm_bwd(dy, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma)
-
-        if len(orig_shape) > 2:
-            dx = dx.view(*orig_shape)
-        return dx, dgamma, dbeta
-
-    @_convert_dtype_params
+        return tex.layernorm_bwd(
+            dz, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma
+        )
     def rmsnorm_fwd(
         self,
         input: torch.Tensor,
@@ -453,52 +461,38 @@ class CUDABackend(TEFLBackendBase):
         eps: float,
         ln_out: Optional[torch.Tensor],
         quantizer: Any,
-        otype: torch.dtype,
+        otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = input.shape
-        if input.ndim > 2:
-            input = input.view(-1, input.shape[-1])
-
-        y, y_quant, rsigma = tex.rmsnorm_fwd(
+        otype = tex.DType(int(otype)) if otype is not None else None
+        return tex.rmsnorm_fwd(
             input, weight, eps, ln_out, quantizer, otype, sm_margin, zero_centered_gamma
         )
-
-        if len(orig_shape) > 2:
-            y = y.view(*orig_shape)
-            if y_quant is not None:
-                y_quant = y_quant.view(*orig_shape)
-        return y, y_quant, rsigma
-
     def rmsnorm_bwd(
         self,
-        dy: torch.Tensor,
+        dz: torch.Tensor,
         x: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
         sm_margin: int = 0,
         zero_centered_gamma: bool = False,
-        eps: float = 1e-5,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = dy.shape
-        if dy.ndim > 2:
-            dy = dy.view(-1, dy.shape[-1])
-            x = x.view(-1, x.shape[-1])
-
-        dx, dw = tex.rmsnorm_bwd(dy, x, rsigma, gamma, sm_margin, zero_centered_gamma)
-
-        if len(orig_shape) > 2:
-            dx = dx.view(*orig_shape)
-        return dx, dw
-
-    def rmsnorm_bwd_add(self, *args, **kwargs) -> Any:
+        return tex.rmsnorm_bwd(dz, x, rsigma, gamma, sm_margin, zero_centered_gamma)
+    def rmsnorm_bwd_add(
+        self,
+        dz: torch.Tensor,
+        x: torch.Tensor,
+        add: torch.Tensor,
+        rsigma: torch.Tensor,
+        gamma: torch.Tensor,
+        sm_margin: int = 0,
+        zero_centered_gamma: bool = False,
+    ) -> Any:
         tex = self._get_tex()
-        return tex.rmsnorm_bwd_add(*args, **kwargs)
+        return tex.rmsnorm_bwd_add(dz, x, add, rsigma, gamma, sm_margin, zero_centered_gamma)
 
     def multi_tensor_quantize(
         self,
@@ -507,7 +501,6 @@ class CUDABackend(TEFLBackendBase):
     ) -> List[Any]:
         tex = self._get_tex()
         return tex.multi_tensor_quantize(tensor_list, quantizer_list)
-
     def split_quantize(
         self,
         tensor: torch.Tensor,
@@ -516,354 +509,86 @@ class CUDABackend(TEFLBackendBase):
     ) -> List[Any]:
         tex = self._get_tex()
         return tex.split_quantize(tensor, split_sections, quantizer_list)
-
-    def moe_permute_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.moe_permute_fwd(*args, **kwargs)
-
-    def moe_permute_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.moe_permute_bwd(*args, **kwargs)
-
-    def moe_unpermute_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.moe_unpermute_fwd(*args, **kwargs)
-
-    def moe_unpermute_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.moe_unpermute_bwd(*args, **kwargs)
-
-    def scaled_softmax_forward(self, input: torch.Tensor, scale: float) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_softmax_forward(input, scale)
-
-    def scaled_softmax_backward(
+    def te_general_grouped_gemm(
         self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
+        A: torch.Tensor,
+        transa: bool,
+        B: torch.Tensor,
+        transb: bool,
+        D: Optional[List[torch.Tensor]],
+        D_type: DType,
+        m_splits: List[int],
+        bias: List[torch.Tensor],
+        bias_type: DType,
+        single_output: bool,
+        pre_gelu_out: List[torch.Tensor],
+        grad: bool,
+        workspace: List[torch.Tensor],
+        workspaceSizes: int,
+        accumulate: bool,
+        use_split_accumulator: bool,
+        math_sm_count: int,
+    ) -> Optional[List[torch.Tensor]]:
         tex = self._get_tex()
-        return tex.scaled_softmax_backward(output_grad, softmax_output, scale)
-
-    def scaled_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        mask: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_masked_softmax_forward(input, mask, scale)
-
-    def scaled_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_masked_softmax_backward(output_grad, softmax_output, scale)
-
-    def scaled_upper_triang_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_upper_triang_masked_softmax_forward(input, scale)
-
-    def scaled_upper_triang_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_upper_triang_masked_softmax_backward(output_grad, softmax_output, scale)
-
-    def scaled_aligned_causal_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_aligned_causal_masked_softmax_forward(input, scale)
-
-    def scaled_aligned_causal_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_aligned_causal_masked_softmax_backward(output_grad, softmax_output, scale)
-
-    def get_fused_attn_backend(self, *args, **kwargs) -> int:
-        tex = self._get_tex()
-
-        args_list = list(args)
-
-        def convert_enum(py_enum, native_enum_class):
-            if py_enum is None:
-                return None
-
-            if type(py_enum).__module__ == 'transformer_engine_torch_nv':
-                return py_enum
-
-            if hasattr(py_enum, 'name'):
-                enum_name = py_enum.name
-                if hasattr(native_enum_class, enum_name):
-                    return getattr(native_enum_class, enum_name)
-
-            if hasattr(py_enum, 'value'):
-                enum_value = int(py_enum.value)
-                for member_name in dir(native_enum_class):
-                    if not member_name.startswith('_'):
-                        try:
-                            member = getattr(native_enum_class, member_name)
-                            if hasattr(member, 'value') and int(member.value) == enum_value:
-                                return member
-                        except:
-                            pass
-
-            if hasattr(py_enum, 'value'):
-                return int(py_enum.value)
-
-            return py_enum
-
-        if len(args) > 1:
-            args_list[1] = self._to_te_dtype(args[1])
-        if len(args) > 2:
-            args_list[2] = self._to_te_dtype(args[2])
-        if len(args) > 3:
-            args_list[3] = convert_enum(args[3], tex.NVTE_QKV_Layout)
-        if len(args) > 4:
-            args_list[4] = convert_enum(args[4], tex.NVTE_Bias_Type)
-        if len(args) > 5:
-            args_list[5] = convert_enum(args[5], tex.NVTE_Mask_Type)
-        if len(args) > 6:
-            args_list[6] = convert_enum(args[6], tex.NVTE_Softmax_Type)
-
-        return tex.get_fused_attn_backend(*args_list, **kwargs)
-
-    def fused_attn_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-
-        def convert_enum(py_enum, native_enum_class):
-            if py_enum is None:
-                return None
-            if type(py_enum).__module__ == 'transformer_engine_torch_nv':
-                return py_enum
-            if hasattr(py_enum, 'name'):
-                enum_name = py_enum.name
-                if hasattr(native_enum_class, enum_name):
-                    return getattr(native_enum_class, enum_name)
-            return py_enum
-
-        args_list = list(args)
-        if len(args) > 6:
-            args_list[6] = convert_enum(args[6], tex.NVTE_QKV_Layout)
-        if len(args) > 7:
-            args_list[7] = convert_enum(args[7], tex.NVTE_Bias_Type)
-        if len(args) > 8:
-            args_list[8] = convert_enum(args[8], tex.NVTE_Mask_Type)
-        if len(args) > 9:
-            args_list[9] = convert_enum(args[9], tex.NVTE_Softmax_Type)
-
-        return tex.fused_attn_fwd(*args_list, **kwargs)
-
-    def fused_attn_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-
-        def convert_enum(py_enum, native_enum_class):
-            if py_enum is None:
-                return None
-            if type(py_enum).__module__ == 'transformer_engine_torch_nv':
-                return py_enum
-            if hasattr(py_enum, 'name'):
-                enum_name = py_enum.name
-                if hasattr(native_enum_class, enum_name):
-                    return getattr(native_enum_class, enum_name)
-            return py_enum
-
-        args_list = list(args)
-        if len(args) > 5:
-            args_list[5] = convert_enum(args[5], tex.NVTE_QKV_Layout)
-        if len(args) > 6:
-            args_list[6] = convert_enum(args[6], tex.NVTE_Bias_Type)
-        if len(args) > 7:
-            args_list[7] = convert_enum(args[7], tex.NVTE_Mask_Type)
-        if len(args) > 8:
-            args_list[8] = convert_enum(args[8], tex.NVTE_Softmax_Type)
-        if len(args) > 19:
-            args_list[19] = self._to_te_dtype(args[19])
-
-        if 'dqkv_dtype' in kwargs:
-            kwargs['dqkv_dtype'] = self._to_te_dtype(kwargs['dqkv_dtype'])
-
-        return tex.fused_attn_bwd(*args_list, **kwargs)
-
-    def fa_prepare_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fa_prepare_fwd(*args, **kwargs)
-
-    def fa_prepare_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fa_prepare_bwd(*args, **kwargs)
-
-    def copy_to_kv_cache(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.copy_to_kv_cache(*args, **kwargs)
-
-    def convert_thd_to_bshd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.convert_thd_to_bshd(*args, **kwargs)
-
-    def convert_bshd_to_thd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.convert_bshd_to_thd(*args, **kwargs)
-
-    def fused_rope_forward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_rope_forward(*args, **kwargs)
-
-    def fused_rope_backward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_rope_backward(*args, **kwargs)
-
-    def fused_qkv_rope_forward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_qkv_rope_forward(*args, **kwargs)
-
-    def fused_qkv_rope_backward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_qkv_rope_backward(*args, **kwargs)
-
-    def fused_topk_with_score_function_fwd(
-        self,
-        logits: torch.Tensor,
-        topk: int,
-        use_pre_softmax: bool,
-        num_groups: int,
-        group_topk: int,
-        scaling_factor: float,
-        score_function: Any,
-        expert_bias: Optional[torch.Tensor],
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_topk_with_score_function_fwd(
-            logits, topk, use_pre_softmax, num_groups, group_topk,
-            scaling_factor, score_function, expert_bias
+        D_type = tex.DType(int(D_type)) if D_type is not None else None
+        bias_type = tex.DType(int(bias_type)) if bias_type is not None else None
+        return tex.te_general_grouped_gemm(
+            A, transa, B, transb, D, D_type, m_splits, bias, bias_type,
+            single_output, pre_gelu_out, grad, workspace, workspaceSizes,
+            accumulate, use_split_accumulator, math_sm_count
         )
-
-    def fused_topk_with_score_function_bwd(
-        self,
-        num_tokens: int,
-        num_experts: int,
-        routing_map: torch.Tensor,
-        intermediate_output: torch.Tensor,
-        grad_probs: torch.Tensor,
-        topk: int,
-        use_pre_softmax: bool,
-        scaling_factor: float,
-        score_function: Any,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_topk_with_score_function_bwd(
-            num_tokens, num_experts, routing_map, intermediate_output,
-            grad_probs, topk, use_pre_softmax, scaling_factor, score_function
-        )
-
-    def fused_score_for_moe_aux_loss_fwd(
-        self,
-        logits: torch.Tensor,
-        topk: int,
-        score_function: Any,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_score_for_moe_aux_loss_fwd(logits, topk, score_function)
-
-    def fused_score_for_moe_aux_loss_bwd(
-        self,
-        num_tokens: int,
-        num_experts: int,
-        intermediate_output: torch.Tensor,
-        grad_scores: torch.Tensor,
-        topk: int,
-        score_function: Any,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_score_for_moe_aux_loss_bwd(
-            num_tokens, num_experts, intermediate_output, grad_scores, topk, score_function
-        )
-
-    def fused_moe_aux_loss_fwd(
-        self,
-        probs: torch.Tensor,
-        tokens_per_expert: torch.Tensor,
-        total_num_tokens: int,
-        num_experts: int,
-        num_rows: int,
-        num_cols: int,
-        topk: int,
-        coeff: float,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_moe_aux_loss_fwd(
-            probs, tokens_per_expert, total_num_tokens, num_experts,
-            num_rows, num_cols, topk, coeff
-        )
-
-    def fused_moe_aux_loss_bwd(
-        self,
-        Const_buf: torch.Tensor,
-        tokens_per_expert: torch.Tensor,
-        num_rows: int,
-        num_cols: int,
-        grad_aux_loss: torch.Tensor,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_moe_aux_loss_bwd(
-            Const_buf, tokens_per_expert, num_rows, num_cols, grad_aux_loss
-        )
-
-    def dropout_fwd(
-        self,
-        input: torch.Tensor,
-        dropout_probability: float,
-        out: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        tex = self._get_tex()
-        return tex.dropout_fwd(input, dropout_probability, out)
-
-    def dropout_bwd(
-        self,
-        grad_output: torch.Tensor,
-        mask: torch.Tensor,
-        dropout_probability: float,
-        grad_input: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.dropout_bwd(grad_output, mask, dropout_probability, grad_input)
-
     def fp8_transpose(
         self,
         input: torch.Tensor,
-        dtype: Any,
-        *,
-        out: torch.Tensor,
-    ) -> None:
+        otype: DType,
+        output: Optional[torch.Tensor],
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        tex.fp8_transpose(input, dtype, out=out)
-
+        otype = tex.DType(int(otype)) if otype is not None else None
+        return tex.fp8_transpose(input, otype, output)
     def swap_first_dims(
         self,
         tensor: torch.Tensor,
-        *,
-        out: torch.Tensor,
-    ) -> None:
+        out: Optional[torch.Tensor],
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        tex.swap_first_dims(tensor, out=out)
+        return tex.swap_first_dims(tensor, out)
+    def get_fused_attn_backend(
+        self,
+        is_training: bool,
+        q_dtype: DType,
+        kv_dtype: DType,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        p_dropout: float,
+        num_attn_heads: int,
+        num_gqa_groups: int,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        head_dim_qk: int,
+        head_dim_v: int,
+        window_size_left: int,
+        window_size_right: int,
+        return_max_logit: bool,
+    ) -> NVTE_Fused_Attn_Backend:
+        tex = self._get_tex()
+
+        q_dtype = tex.DType(int(q_dtype)) if q_dtype is not None else None
+        kv_dtype = tex.DType(int(kv_dtype)) if kv_dtype is not None else None
+        qkv_layout = tex.NVTE_QKV_Layout(int(qkv_layout)) if qkv_layout is not None else None
+        bias_type = tex.NVTE_Bias_Type(int(bias_type)) if bias_type is not None else None
+        attn_mask_type = tex.NVTE_Mask_Type(int(attn_mask_type)) if attn_mask_type is not None else None
+        softmax_type = tex.NVTE_Softmax_Type(int(softmax_type)) if softmax_type is not None else None
+
+        result = tex.get_fused_attn_backend(
+            is_training, q_dtype, kv_dtype, qkv_layout, bias_type,
+            attn_mask_type, softmax_type, p_dropout, num_attn_heads,
+            num_gqa_groups, max_seqlen_q, max_seqlen_kv, head_dim_qk,
+            head_dim_v, window_size_left, window_size_right, return_max_logit
+        )
+        return NVTE_Fused_Attn_Backend(result)
 
     def compute_amax(
         self,
@@ -871,12 +596,22 @@ class CUDABackend(TEFLBackendBase):
         amax: torch.Tensor,
     ) -> None:
         tex = self._get_tex()
-        tex.compute_amax(input, amax)
-
-    def fused_amax_and_scale_update_after_reduction(self, *args, **kwargs) -> None:
+        return tex.compute_amax(input, amax)
+    def fused_amax_and_scale_update_after_reduction(
+        self,
+        amax_reduction_buffer: torch.Tensor,
+        amax_histories: List[torch.Tensor],
+        scales: List[torch.Tensor],
+        amax_compute_algo: str,
+        fp8_dtype: DType,
+        margin: float,
+    ) -> None:
         tex = self._get_tex()
-        tex.fused_amax_and_scale_update_after_reduction(*args, **kwargs)
-
+        fp8_dtype = tex.DType(int(fp8_dtype)) if fp8_dtype is not None else None
+        return tex.fused_amax_and_scale_update_after_reduction(
+            amax_reduction_buffer, amax_histories, scales,
+            amax_compute_algo, fp8_dtype, margin
+        )
     def fp8_block_scaling_compute_partial_amax(
         self,
         tensor: torch.Tensor,
@@ -887,8 +622,9 @@ class CUDABackend(TEFLBackendBase):
         block_len: int,
     ) -> None:
         tex = self._get_tex()
-        tex.fp8_block_scaling_compute_partial_amax(tensor, amax, h, w, start_offset, block_len)
-
+        return tex.fp8_block_scaling_compute_partial_amax(
+            tensor, amax, h, w, start_offset, block_len
+        )
     def fp8_block_scaling_partial_cast(
         self,
         inp: torch.Tensor,
@@ -898,75 +634,555 @@ class CUDABackend(TEFLBackendBase):
         w: int,
         start_offset: int,
         block_len: int,
-        out_dtype: Any,
+        out_dtype: DType,
     ) -> None:
         tex = self._get_tex()
-        tex.fp8_block_scaling_partial_cast(inp, out, scale, h, w, start_offset, block_len, out_dtype)
-
-    def fused_multi_row_padding(self, *args, **kwargs) -> Any:
+        out_dtype = tex.DType(int(out_dtype)) if out_dtype is not None else None
+        return tex.fp8_block_scaling_partial_cast(
+            inp, out, scale, h, w, start_offset, block_len, out_dtype
+        )
+    def fused_multi_row_padding(
+        self,
+        input: torch.Tensor,
+        output: torch.Tensor,
+        input_row_list: List[int],
+        padded_input_row_list: List[int],
+    ) -> None:
         tex = self._get_tex()
-        return tex.fused_multi_row_padding(*args, **kwargs)
-
-    def fused_multi_row_unpadding(self, *args, **kwargs) -> Any:
+        return tex.fused_multi_row_padding(
+            input, output, input_row_list, padded_input_row_list
+        )
+    def fused_multi_row_unpadding(
+        self,
+        input: torch.Tensor,
+        output: torch.Tensor,
+        input_row_list: List[int],
+        unpadded_input_row_list: List[int],
+    ) -> None:
         tex = self._get_tex()
-        return tex.fused_multi_row_unpadding(*args, **kwargs)
+        return tex.fused_multi_row_unpadding(
+            input, output, input_row_list, unpadded_input_row_list
+        )
 
+    # attention kernels
+    def fa_prepare_fwd(
+        self,
+        qkvi: torch.Tensor,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fa_prepare_fwd(qkvi)
+    def fa_prepare_bwd(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fa_prepare_bwd(q, k, v)
+    def fused_attn_fwd(
+        self,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        is_training: bool,
+        attn_scale: float,
+        p_dropout: float,
+        set_zero: bool,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        window_size: List[int],
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_kv: torch.Tensor,
+        Q: Any,
+        K: Any,
+        V: Any,
+        fake_dtype: torch.dtype,
+        cu_seqlens_q_padded: Optional[torch.Tensor],
+        cu_seqlens_kv_padded: Optional[torch.Tensor],
+        page_table_k: Optional[torch.Tensor],
+        page_table_v: Optional[torch.Tensor],
+        s_quantizer: Any,
+        o_quantizer: Any,
+        Bias: Optional[torch.Tensor],
+        SoftmaxOffset: Optional[torch.Tensor],
+        rng_gen: Optional[torch.Generator],
+        rng_elts_per_thread: int,
+        return_max_logit: bool,
+    ) -> List[Any]:
+        tex = self._get_tex()
+
+        qkv_layout = tex.NVTE_QKV_Layout(int(qkv_layout)) if qkv_layout is not None else None
+        bias_type = tex.NVTE_Bias_Type(int(bias_type)) if bias_type is not None else None
+        attn_mask_type = tex.NVTE_Mask_Type(int(attn_mask_type)) if attn_mask_type is not None else None
+        softmax_type = tex.NVTE_Softmax_Type(int(softmax_type)) if softmax_type is not None else None
+
+        return tex.fused_attn_fwd(
+            max_seqlen_q,
+            max_seqlen_kv,
+            is_training,
+            attn_scale,
+            p_dropout,
+            set_zero,
+            qkv_layout,
+            bias_type,
+            attn_mask_type,
+            softmax_type,
+            window_size,
+            cu_seqlens_q,
+            cu_seqlens_kv,
+            Q,
+            K,
+            V,
+            fake_dtype,
+            cu_seqlens_q_padded,
+            cu_seqlens_kv_padded,
+            page_table_k,
+            page_table_v,
+            s_quantizer,
+            o_quantizer,
+            Bias,
+            SoftmaxOffset,
+            rng_gen,
+            rng_elts_per_thread,
+            return_max_logit
+        )
+    def fused_attn_bwd(
+        self,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        attn_scale: float,
+        p_dropout: float,
+        set_zero: bool,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        window_size: List[int],
+        deterministic: bool,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_kv: torch.Tensor,
+        Q: Any,
+        K: Any,
+        V: Any,
+        O: Any,
+        dO: Any,
+        fake_dtype: torch.dtype,
+        dqkv_type: DType,
+        Aux_CTX_Tensors: List[torch.Tensor],
+        cu_seqlens_q_padded: Optional[torch.Tensor],
+        cu_seqlens_kv_padded: Optional[torch.Tensor],
+        s_quantizer: Any,
+        dp_quantizer: Any,
+        dqkv_quantizer: Any,
+    ) -> List[Any]:
+        tex = self._get_tex()
+
+        qkv_layout = tex.NVTE_QKV_Layout(int(qkv_layout)) if qkv_layout is not None else None
+        bias_type = tex.NVTE_Bias_Type(int(bias_type)) if bias_type is not None else None
+        attn_mask_type = tex.NVTE_Mask_Type(int(attn_mask_type)) if attn_mask_type is not None else None
+        softmax_type = tex.NVTE_Softmax_Type(int(softmax_type)) if softmax_type is not None else None
+        dqkv_type = tex.DType(int(dqkv_type)) if dqkv_type is not None else None
+
+        return tex.fused_attn_bwd(
+            max_seqlen_q,
+            max_seqlen_kv,
+            attn_scale,
+            p_dropout,
+            set_zero,
+            qkv_layout,
+            bias_type,
+            attn_mask_type,
+            softmax_type,
+            window_size,
+            deterministic,
+            cu_seqlens_q,
+            cu_seqlens_kv,
+            Q,
+            K,
+            V,
+            O,
+            dO,
+            fake_dtype,
+            dqkv_type,
+            Aux_CTX_Tensors,
+            cu_seqlens_q_padded,
+            cu_seqlens_kv_padded,
+            s_quantizer,
+            dp_quantizer,
+            dqkv_quantizer
+        )
+    def copy_to_kv_cache(
+        self,
+        new_k: torch.Tensor,
+        new_v: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        page_table: torch.Tensor,
+        cu_new_lens: torch.Tensor,
+        cu_cached_lens: torch.Tensor,
+        qkv_format: NVTE_QKV_Format,
+        b: int,
+        max_ctx_len: int,
+        max_seq_len: int,
+        max_pages_per_seq: int,
+        is_non_paged: bool,
+    ) -> None:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.copy_to_kv_cache(
+            new_k,
+            new_v,
+            k_cache,
+            v_cache,
+            page_table,
+            cu_new_lens,
+            cu_cached_lens,
+            qkv_format,
+            b,
+            max_ctx_len,
+            max_seq_len,
+            max_pages_per_seq,
+            is_non_paged
+        )
+    def convert_thd_to_bshd(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        b: int,
+        max_seq_len: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.convert_thd_to_bshd(tensor, cu_seqlens, b, max_seq_len)
+    def convert_bshd_to_thd(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        t: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.convert_bshd_to_thd(tensor, cu_seqlens, t)
+
+    # fused apply rope
+    def fused_rope_forward(
+        self,
+        input: torch.Tensor,
+        freqs: torch.Tensor,
+        start_positions: Optional[torch.Tensor],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cu_seqlens: Optional[torch.Tensor],
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_rope_forward(
+            input, freqs, start_positions, qkv_format,
+            interleaved, cu_seqlens, cp_size, cp_rank
+        )
+    def fused_rope_backward(
+        self,
+        output_grads: torch.Tensor,
+        freqs: torch.Tensor,
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cu_seqlens: Optional[torch.Tensor],
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_rope_backward(
+            output_grads, freqs, qkv_format,
+            interleaved, cu_seqlens, cp_size, cp_rank
+        )
+    def fused_qkv_rope_forward(
+        self,
+        qkv_input: torch.Tensor,
+        q_freqs: torch.Tensor,
+        k_freqs: torch.Tensor,
+        start_positions: Optional[torch.Tensor],
+        qkv_split_arg_list: List[int],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cp_size: int,
+        cp_rank: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_qkv_rope_forward(
+            qkv_input, q_freqs, k_freqs, start_positions,
+            qkv_split_arg_list, qkv_format, interleaved,
+            cp_size, cp_rank
+        )
+    def fused_qkv_rope_backward(
+        self,
+        q_grad_out: torch.Tensor,
+        k_grad_out: torch.Tensor,
+        v_grad_out: torch.Tensor,
+        q_freqs: torch.Tensor,
+        k_freqs: torch.Tensor,
+        qkv_split_arg_list: List[int],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_qkv_rope_backward(
+            q_grad_out, k_grad_out, v_grad_out,
+            q_freqs, k_freqs, qkv_split_arg_list,
+            qkv_format, interleaved, cp_size, cp_rank
+        )
+
+    # fused router
+    def fused_topk_with_score_function_fwd(
+        self,
+        logits: torch.Tensor,
+        topk: int,
+        use_pre_softmax: bool,
+        num_groups: Optional[int],
+        group_topk: Optional[int],
+        scaling_factor: Optional[float],
+        score_function: str,
+        expert_bias: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.fused_topk_with_score_function_fwd(
+            logits,
+            topk,
+            use_pre_softmax,
+            num_groups,
+            group_topk,
+            scaling_factor,
+            score_function,
+            expert_bias,
+        )
+    def fused_topk_with_score_function_bwd(
+        self,
+        num_tokens: int,
+        num_experts: int,
+        routing_map: torch.Tensor,
+        intermediate_output: torch.Tensor,
+        grad_probs: torch.Tensor,
+        topk: int,
+        use_pre_softmax: bool,
+        scaling_factor: Optional[float],
+        score_function: str,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fused_topk_with_score_function_bwd(
+            num_tokens,
+            num_experts,
+            routing_map,
+            intermediate_output,
+            grad_probs,
+            topk,
+            use_pre_softmax,
+            scaling_factor,
+            score_function,
+        )
+    def fused_score_for_moe_aux_loss_fwd(
+        self,
+        logits: torch.Tensor,
+        topk: int,
+        score_function: str,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.fused_score_for_moe_aux_loss_fwd(
+            logits,
+            topk,
+            score_function,
+        )
+    def fused_score_for_moe_aux_loss_bwd(
+        self,
+        num_tokens: int,
+        num_experts: int,
+        intermediate_output: torch.Tensor,
+        grad_scores: torch.Tensor,
+        topk: int,
+        score_function: str,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fused_score_for_moe_aux_loss_bwd(
+            num_tokens,
+            num_experts,
+            intermediate_output,
+            grad_scores,
+            topk,
+            score_function,
+        )
+    def fused_moe_aux_loss_fwd(
+        self,
+        probs: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        total_num_tokens: int,
+        num_experts: int,
+        num_rows: int,
+        num_cols: int,
+        topk: int,
+        coeff: float,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.fused_moe_aux_loss_fwd(
+            probs,
+            tokens_per_expert,
+            total_num_tokens,
+            num_experts,
+            num_rows,
+            num_cols,
+            topk,
+            coeff,
+        )
+    def fused_moe_aux_loss_bwd(
+        self,
+        Const_buf: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        num_rows: int,
+        num_cols: int,
+        grad_aux_loss: torch.Tensor,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fused_moe_aux_loss_bwd(Const_buf, tokens_per_expert, num_rows, num_cols, grad_aux_loss)
+
+    # Dropout
+    def dropout_fwd(
+        self,
+        input: torch.Tensor,
+        dropout_probability: float,
+        out: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.dropout_fwd(input, dropout_probability, out)
+    def dropout_bwd(
+        self,
+        grad_output: torch.Tensor,
+        mask: torch.Tensor,
+        dropout_probability: float,
+        grad_input: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.dropout_bwd(grad_output, mask, dropout_probability, grad_input)
+
+    # Misc
     def get_cublasLt_version(self) -> int:
         tex = self._get_tex()
         return tex.get_cublasLt_version()
-
     def get_cudnn_version(self) -> int:
         tex = self._get_tex()
         return tex.get_cudnn_version()
-
     def get_num_cublas_streams(self) -> int:
         tex = self._get_tex()
         return tex.get_num_cublas_streams()
 
-    def thd_read_half_tensor(self, *args, **kwargs) -> Any:
+    # Support THD format for Context Parallel
+    def thd_read_half_tensor(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        half_idx: int,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.thd_read_half_tensor(*args, **kwargs)
-
-    def thd_second_half_lse_correction(self, *args, **kwargs) -> Any:
+        return tex.thd_read_half_tensor(tensor, cu_seqlens, half_idx)
+    def thd_second_half_lse_correction(
+        self,
+        lse: torch.Tensor,
+        lse_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        lse_packed: bool,
+    ) -> None:
         tex = self._get_tex()
-        return tex.thd_second_half_lse_correction(*args, **kwargs)
-
-    def thd_read_second_half_lse(self, *args, **kwargs) -> Any:
+        return tex.thd_second_half_lse_correction(
+            lse, lse_per_step, cu_seqlens, lse_packed
+        )
+    def thd_read_second_half_lse(
+        self,
+        lse: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        lse_packed: bool,
+        second_half_lse_seqlen: int,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.thd_read_second_half_lse(*args, **kwargs)
-
-    def thd_out_correction(self, *args, **kwargs) -> Any:
+        return tex.thd_read_second_half_lse(
+            lse, cu_seqlens, lse_packed, second_half_lse_seqlen
+        )
+    def thd_out_correction(
+        self,
+        out: torch.Tensor,
+        out_per_step: torch.Tensor,
+        lse: torch.Tensor,
+        lse_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        only_second_half: bool,
+        lse_packed: bool,
+    ) -> None:
         tex = self._get_tex()
-        return tex.thd_out_correction(*args, **kwargs)
-
-    def thd_grad_correction(self, *args, **kwargs) -> Any:
+        return tex.thd_out_correction(
+            out, out_per_step, lse, lse_per_step,
+            cu_seqlens, only_second_half, lse_packed
+        )
+    def thd_grad_correction(
+        self,
+        grad: torch.Tensor,
+        grad_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        first_half: str,
+        second_half: str,
+    ) -> None:
         tex = self._get_tex()
-        return tex.thd_grad_correction(*args, **kwargs)
-
-    def thd_get_partitioned_indices(self, *args, **kwargs) -> Any:
+        return tex.thd_grad_correction(
+            grad, grad_per_step, cu_seqlens,
+            first_half, second_half
+        )
+    def thd_get_partitioned_indices(
+        self,
+        cu_seqlens: torch.Tensor,
+        total_tokens: int,
+        world_size: int,
+        rank: int,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.thd_get_partitioned_indices(*args, **kwargs)
+        return tex.thd_get_partitioned_indices(
+            cu_seqlens, total_tokens, world_size, rank
+        )
 
-    def init_nvshmem_backend(self, *args, **kwargs) -> None:
+    # nvshmem functions
+    def init_nvshmem_backend(
+        self,
+        process_group: Any,
+    ) -> None:
         tex = self._get_tex()
-        tex.init_nvshmem_backend(*args, **kwargs)
-
-    def create_nvshmem_tensor(self, *args, **kwargs) -> torch.Tensor:
+        return tex.init_nvshmem_backend(process_group)
+    def create_nvshmem_tensor(
+        self,
+        shape: List[int],
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.create_nvshmem_tensor(*args, **kwargs)
-
-    def nvshmem_send_on_current_stream(self, *args, **kwargs) -> None:
+        return tex.create_nvshmem_tensor(shape, dtype)
+    def nvshmem_send_on_current_stream(
+        self,
+        src: torch.Tensor,
+        dst: torch.Tensor,
+        peer: int,
+        signal: torch.Tensor,
+    ) -> None:
         tex = self._get_tex()
-        tex.nvshmem_send_on_current_stream(*args, **kwargs)
-
-    def nvshmem_wait_on_current_stream(self, *args, **kwargs) -> None:
+        return tex.nvshmem_send_on_current_stream(src, dst, peer, signal)
+    def nvshmem_wait_on_current_stream(
+        self,
+        signal: torch.Tensor,
+        wait_kind: str,
+    ) -> None:
         tex = self._get_tex()
-        tex.nvshmem_wait_on_current_stream(*args, **kwargs)
-
+        return tex.nvshmem_wait_on_current_stream(signal, wait_kind)
     def nvshmem_finalize(self) -> None:
         tex = self._get_tex()
-        tex.nvshmem_finalize()
+        return tex.nvshmem_finalize()
 
+    # multi-tensor functions
     def multi_tensor_scale(
         self,
         chunk_size: int,
@@ -975,98 +1191,195 @@ class CUDABackend(TEFLBackendBase):
         scale: float,
     ) -> None:
         tex = self._get_tex()
-        tex.multi_tensor_scale(chunk_size, noop_flag, tensor_lists, scale)
-
+        return tex.multi_tensor_scale(chunk_size, noop_flag, tensor_lists, scale)
     def multi_tensor_l2norm(
         self,
         chunk_size: int,
         noop_flag: torch.Tensor,
         tensor_lists: List[List[torch.Tensor]],
-        per_tensor: bool = False,
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
+        per_tensor: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
         return tex.multi_tensor_l2norm(chunk_size, noop_flag, tensor_lists, per_tensor)
-
     def multi_tensor_unscale_l2norm(
         self,
         chunk_size: int,
         noop_flag: torch.Tensor,
         tensor_lists: List[List[torch.Tensor]],
-        scale: torch.Tensor,
-        per_tensor: bool = False,
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
+        inv_scale: torch.Tensor,
+        per_tensor: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-        return tex.multi_tensor_unscale_l2norm(chunk_size, noop_flag, tensor_lists, scale, per_tensor)
-
+        return tex.multi_tensor_unscale_l2norm(
+            chunk_size, noop_flag, tensor_lists, inv_scale, per_tensor
+        )
     def multi_tensor_adam(
         self,
-        chunk_size: int = None,
-        noop_flag: torch.Tensor = None,
-        tensor_lists: List[List[torch.Tensor]] = None,
-        lr: float = None,
-        beta1: float = None,
-        beta2: float = None,
-        eps: float = None,
-        step: int = None,
-        mode: int = None,
-        bias_correction: int = None,
-        weight_decay: float = None,
-    ):
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
         tex = self._get_tex()
-        if chunk_size is None:
-            return tex.multi_tensor_adam
-        tex.multi_tensor_adam(
-            chunk_size, noop_flag, tensor_lists, lr, beta1, beta2,
-            eps, step, mode, bias_correction, weight_decay
+        return tex.multi_tensor_adam(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay
+        )
+    def multi_tensor_adam_param_remainder(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_adam_param_remainder(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay
+        )
+    def multi_tensor_adam_fp8(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        fp8_dtype: DType,
+    ) -> None:
+        tex = self._get_tex()
+        fp8_dtype = tex.DType(int(fp8_dtype)) if fp8_dtype is not None else None
+        return tex.multi_tensor_adam_fp8(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
+            fp8_dtype
+        )
+    def multi_tensor_adam_capturable(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: torch.Tensor,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: torch.Tensor,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        inv_scale: torch.Tensor,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_adam_capturable(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
+            inv_scale
+        )
+    def multi_tensor_adam_capturable_master(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: torch.Tensor,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: torch.Tensor,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        inv_scale: torch.Tensor,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_adam_capturable_master(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
+            inv_scale
+        )
+    def multi_tensor_sgd(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        wd: float,
+        momentum: float,
+        dampening: float,
+        lr: float,
+        nesterov: bool,
+        first_run: bool,
+        wd_after_momentum: bool,
+        scale: float,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_sgd(
+            chunk_size, noop_flag, tensor_lists,
+            wd, momentum, dampening,
+            lr, nesterov, first_run,
+            wd_after_momentum, scale
+        )
+    def multi_tensor_compute_scale_and_scale_inv(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        max_fp8: float,
+        force_pow_2_scales: bool,
+        epsilon: float,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_compute_scale_and_scale_inv(
+            chunk_size, noop_flag, tensor_lists,
+            max_fp8, force_pow_2_scales, epsilon
         )
 
-    def multi_tensor_adam_param_remainder(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_param_remainder(*args, **kwargs)
-
-    def multi_tensor_adam_fp8(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_fp8(*args, **kwargs)
-
-    def multi_tensor_adam_capturable(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_capturable(*args, **kwargs)
-
-    def multi_tensor_adam_capturable_master(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_capturable_master(*args, **kwargs)
-
-    def multi_tensor_sgd(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_sgd(*args, **kwargs)
-
-    def multi_tensor_compute_scale_and_scale_inv(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_compute_scale_and_scale_inv(*args, **kwargs)
-
+    # Comm+GEMM Overlap
     def bulk_overlap_ag_with_external_gemm(
         self,
-        allgather_communicator: Any,
+        allgather_communicator: CommOverlap,
         send_stream: Any,
         recv_stream: Any,
     ) -> Any:
         tex = self._get_tex()
         return tex.bulk_overlap_ag_with_external_gemm(allgather_communicator, send_stream, recv_stream)
 
+############## class func #################################
+    def get_flash_attention_class(self):
+        from .flash_attention import FlashAttentionCUDA
+        return FlashAttentionCUDA
     def create_fp8_tensor_meta(self) -> FP8TensorMeta:
         tex = self._get_tex()
         return tex.FP8TensorMeta()
-
     def create_comm_overlap_helper(
         self,
         world_group: Optional[Any] = None,
         intra_node_group: Optional[Any] = None,
-    ) -> Any:
+    ) -> "CommOverlapHelper":
         tex = self._get_tex()
-        if world_group is None:
-            return tex.CommOverlapHelper()
         return tex.CommOverlapHelper(world_group, intra_node_group)
-
     def create_comm_overlap(
         self,
         buffer_shape: List[int],
@@ -1082,7 +1395,7 @@ class CUDABackend(TEFLBackendBase):
         set_sm_margin: bool = True,
         atomic_gemm: bool = False,
         rs_overlap_first_gemm: bool = False,
-    ) -> Any:
+    ) -> "CommOverlap":
         tex = self._get_tex()
         return tex.CommOverlap(
             buffer_shape, buffer_dtype, helper, tp_size,
@@ -1090,7 +1403,6 @@ class CUDABackend(TEFLBackendBase):
             gemm_priority, comm_priority, num_comm_sm,
             set_sm_margin, atomic_gemm, rs_overlap_first_gemm
         )
-
     def create_comm_overlap_p2p(
         self,
         buffer_shape: List[int],
@@ -1107,7 +1419,7 @@ class CUDABackend(TEFLBackendBase):
         atomic_gemm: bool = False,
         use_ce: bool = True,
         aggregate: bool = False,
-    ) -> Any:
+    ) -> "CommOverlapP2P":
         tex = self._get_tex()
         return tex.CommOverlapP2P(
             buffer_shape, buffer_dtype, helper, tp_size, comm_type,

--- a/transformer_engine/plugin/core/backends/vendor/cuda/cuda.py
+++ b/transformer_engine/plugin/core/backends/vendor/cuda/cuda.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2025, BAAI. All rights reserved.
 #
 # See LICENSE for license information.
-
+import os
+import sys
 from typing import Any, Dict, List, Optional, Tuple, Union
-
 import torch
-
 from ....ops import *
 
 def _load_cuda_libs():

--- a/transformer_engine/plugin/core/backends/vendor/cuda/cuda.py
+++ b/transformer_engine/plugin/core/backends/vendor/cuda/cuda.py
@@ -166,26 +166,26 @@ class CUDABackend(TEFLBackendBase):
         self,
         input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.bgrad_quantize(input, quantizer)
 
     def generic_gemm(
         self,
         A: Any,
-        transa: bool,
+        transA: bool,
         B: Any,
-        transb: bool,
+        transB: bool,
         D: Any,
         quantizer: Any,
-        out_dtype: Optional[DType],
+        output_dtype: Optional[DType],
         bias: Optional[torch.Tensor],
         bias_type: DType,
         gelu: bool,
         gelu_in: Optional[torch.Tensor],
         grad: bool,
         workspace: torch.Tensor,
-        workspaceSize: int,
+        workspace_size: int,
         accumulate: bool,
         use_split_accumulator: bool,
         comm_overlap: Optional[Any] = None,
@@ -199,10 +199,10 @@ class CUDABackend(TEFLBackendBase):
         
         bias_type = tex.DType(int(bias_type)) if bias_type is not None else None
         comm_type = tex.CommOverlapType(int(comm_type)) if comm_type is not None else None
-        out_dtype = tex.DType(int(out_dtype)) if out_dtype is not None else None
+        output_dtype = tex.DType(int(output_dtype)) if output_dtype is not None else None
         return tex.generic_gemm(
-            A, transa, B, transb, D, quantizer, out_dtype,
-            bias, bias_type, gelu, gelu_in, grad, workspace, workspaceSize,
+            A, transA, B, transB, D, quantizer, output_dtype,
+            bias, bias_type, gelu, gelu_in, grad, workspace, workspace_size,
             accumulate, use_split_accumulator, comm_overlap, comm_type,
             extra_output, bulk_overlap, alpha, beta
         )
@@ -292,19 +292,19 @@ class CUDABackend(TEFLBackendBase):
         tex = self._get_tex()
         return tex.clamped_dswiglu(grad, fwd_input, quantizer, limit, alpha)
     # DBias + DAct fusions #
-    def dbias_dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dgelu(grad, fwd_input, quantizer)
-    def dbias_dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dsilu(grad, fwd_input, quantizer)
-    def dbias_drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_drelu(grad, fwd_input, quantizer)
-    def dbias_dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dqgelu(grad, fwd_input, quantizer)
-    def dbias_dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dsrelu(grad, fwd_input, quantizer)
     # Permutation functions                                                                                                                                                                                                                                                                                             
@@ -428,12 +428,12 @@ class CUDABackend(TEFLBackendBase):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor],
         eps: float,
-        ln_out: Optional[torch.Tensor],
+        ln_out: Any,
         quantizer: Any,
         otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> List[Any]:
         tex = self._get_tex()
         otype = tex.DType(int(otype)) if otype is not None else None
         return tex.layernorm_fwd(
@@ -446,24 +446,24 @@ class CUDABackend(TEFLBackendBase):
         mu: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.layernorm_bwd(
             dz, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma
         )
     def rmsnorm_fwd(
         self,
-        input: torch.Tensor,
-        weight: torch.Tensor,
+        input: Any,
+        weight: Any,
         eps: float,
-        ln_out: Optional[torch.Tensor],
+        ln_out: Any,
         quantizer: Any,
         otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    ) -> List[Any]:
         tex = self._get_tex()
         otype = tex.DType(int(otype)) if otype is not None else None
         return tex.rmsnorm_fwd(
@@ -475,9 +475,9 @@ class CUDABackend(TEFLBackendBase):
         x: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.rmsnorm_bwd(dz, x, rsigma, gamma, sm_margin, zero_centered_gamma)
     def rmsnorm_bwd_add(
@@ -487,9 +487,9 @@ class CUDABackend(TEFLBackendBase):
         add: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Any:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.rmsnorm_bwd_add(dz, x, add, rsigma, gamma, sm_margin, zero_centered_gamma)
 
@@ -510,9 +510,9 @@ class CUDABackend(TEFLBackendBase):
         return tex.split_quantize(tensor, split_sections, quantizer_list)
     def te_general_grouped_gemm(
         self,
-        A: torch.Tensor,
+        A: List[Any],
         transa: bool,
-        B: torch.Tensor,
+        B: List[Any],
         transb: bool,
         D: Optional[List[torch.Tensor]],
         D_type: DType,
@@ -539,12 +539,12 @@ class CUDABackend(TEFLBackendBase):
     def fp8_transpose(
         self,
         input: torch.Tensor,
-        otype: DType,
-        output: Optional[torch.Tensor],
+        dtype: DType,
+        out: Optional[torch.Tensor],
     ) -> torch.Tensor:
         tex = self._get_tex()
-        otype = tex.DType(int(otype)) if otype is not None else None
-        return tex.fp8_transpose(input, otype, output)
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.fp8_transpose(input, dtype, out)
     def swap_first_dims(
         self,
         tensor: torch.Tensor,

--- a/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
+++ b/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
@@ -5,10 +5,8 @@
 import os
 import sys
 from typing import Any, Dict, List, Optional, Tuple, Union
-
 import torch
-
-from ....ops import TEFLBackendBase, FP8TensorMeta, NVTE_Fused_Attn_Backend
+from ....ops import *
 
 def _load_hygon_libs():
     import ctypes
@@ -78,69 +76,6 @@ def _get_tex():
     import transformer_engine_torch_hygon
     return transformer_engine_torch_hygon
 
-def _torch_dtype_to_te_dtype(torch_dtype, tex_module):
-    if torch_dtype is None:
-        return None
-
-    NativeDType = tex_module.DType
-    if type(torch_dtype).__name__ == 'DType' and type(torch_dtype).__module__ == 'transformer_engine_torch_hygon':
-        return torch_dtype
-
-    if hasattr(torch_dtype, 'name') and hasattr(torch_dtype, 'value'):
-        from transformer_engine.plugin.core.ops import DType as PyDType
-        if isinstance(torch_dtype, PyDType):
-            dtype_name = torch_dtype.name
-            if hasattr(NativeDType, dtype_name):
-                return getattr(NativeDType, dtype_name)
-
-    dtype_map = {
-        torch.float32: NativeDType.kFloat32,
-        torch.float16: NativeDType.kFloat16,
-        torch.bfloat16: NativeDType.kBFloat16,
-        torch.int32: NativeDType.kInt32,
-        torch.uint8: NativeDType.kByte,
-    }
-
-    if hasattr(torch, 'float8_e4m3fn'):
-        dtype_map[torch.float8_e4m3fn] = NativeDType.kFloat8E4M3
-    if hasattr(torch, 'float8_e5m2'):
-        dtype_map[torch.float8_e5m2] = NativeDType.kFloat8E5M2
-
-    return dtype_map.get(torch_dtype, torch_dtype)
-
-def _convert_dtype_params(func):
-    import functools
-    import inspect
-
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        dtype_params = ['otype', 'output_dtype', 'bias_type']
-
-        from transformer_engine.plugin.core.ops import DType as PyDType
-
-        def needs_conversion(val):
-            return isinstance(val, torch.dtype) or isinstance(val, PyDType)
-
-        for param_name in dtype_params:
-            if param_name in kwargs:
-                value = kwargs[param_name]
-                if needs_conversion(value):
-                    converted = self._to_te_dtype(value)
-                    kwargs[param_name] = converted
-
-        sig = inspect.signature(func)
-        param_names = list(sig.parameters.keys())[1:]
-
-        args_list = list(args)
-        for i, (param_name, arg_value) in enumerate(zip(param_names, args_list)):
-            if param_name in dtype_params and needs_conversion(arg_value):
-                converted = self._to_te_dtype(arg_value)
-                args_list[i] = converted
-
-        return func(self, *args_list, **kwargs)
-
-    return wrapper
-
 class HygonBackend(TEFLBackendBase):
     @staticmethod
     def check_available() -> bool:
@@ -154,15 +89,8 @@ class HygonBackend(TEFLBackendBase):
             self._tex = _get_tex()
         return self._tex
 
-    def _to_te_dtype(self, torch_dtype):
-        return _torch_dtype_to_te_dtype(torch_dtype, self._get_tex())
-
     def is_available(self) -> bool:
         return _check_hygon_available()
-
-    def get_flash_attention_class(self):
-        from .flash_attention import FlashAttentionHYGON
-        return FlashAttentionHYGON
 
     def get_attention_backend(self, attention_params=None):
         from packaging.version import Version as PkgVersion
@@ -196,6 +124,7 @@ class HygonBackend(TEFLBackendBase):
             available_backends,
         )
 
+##### transformer_engine/pytorch/csrc/extensions/pybind.cpp #####
     def quantize(
         self,
         tensor: torch.Tensor,
@@ -206,105 +135,92 @@ class HygonBackend(TEFLBackendBase):
         tex = self._get_tex()
         return tex.quantize(tensor, quantizer, output, noop)
 
-    @_convert_dtype_params
     def dequantize(
         self,
-        input: torch.Tensor,
-        otype: torch.dtype,
-    ) -> torch.Tensor:
+        input: Any,
+        otype: DType,
+    ) -> Any:
         tex = self._get_tex()
+        otype = tex.DType(int(otype)) if otype is not None else None
         return tex.dequantize(input, otype)
 
     def bgrad_quantize(
         self,
         input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
         return tex.bgrad_quantize(input, quantizer)
 
-    @_convert_dtype_params
     def generic_gemm(
         self,
-        A: torch.Tensor,
-        transA: bool,
-        B: torch.Tensor,
-        transB: bool,
-        D: torch.Tensor,
+        A: Any,
+        transa: bool,
+        B: Any,
+        transb: bool,
+        D: Any,
         quantizer: Any,
-        output_dtype: torch.dtype,
+        out_dtype: Optional[DType],
         bias: Optional[torch.Tensor],
-        bias_type: Any,
+        bias_type: DType,
         gelu: bool,
         gelu_in: Optional[torch.Tensor],
         grad: bool,
         workspace: torch.Tensor,
-        workspace_size: int,
+        workspaceSize: int,
         accumulate: bool,
         use_split_accumulator: bool,
         comm_overlap: Optional[Any] = None,
-        comm_type: Optional[Any] = None,
+        comm_type: Optional[CommOverlapType] = None,
         extra_output: Optional[torch.Tensor] = None,
         bulk_overlap: bool = False,
         alpha: float = 1.0,
         beta: Optional[float] = None,
-    ) -> Any:
+    ) -> List[Any]:
         tex = self._get_tex()
-
-        if bias_type is None:
-            bias_type = self._to_te_dtype(torch.bfloat16)
-
+        
+        bias_type = tex.DType(int(bias_type)) if bias_type is not None else None
+        comm_type = tex.CommOverlapType(int(comm_type)) if comm_type is not None else None
+        out_dtype = tex.DType(int(out_dtype)) if out_dtype is not None else None
         return tex.generic_gemm(
-            A, transA, B, transB, D, quantizer, output_dtype,
-            bias, bias_type, gelu, gelu_in, grad, workspace, workspace_size,
+            A, transa, B, transb, D, quantizer, out_dtype,
+            bias, bias_type, gelu, gelu_in, grad, workspace, workspaceSize,
             accumulate, use_split_accumulator, comm_overlap, comm_type,
             extra_output, bulk_overlap, alpha, beta
         )
-
-    def te_general_grouped_gemm(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.te_general_grouped_gemm(*args, **kwargs)
-
+    # GELU and variants #
     def gelu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.gelu(input, quantizer)
-
     def geglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.geglu(input, quantizer)
-
     def qgelu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.qgelu(input, quantizer)
-
     def qgeglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.qgeglu(input, quantizer)
-
+    # ReLU and variants #
     def relu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.relu(input, quantizer)
-
     def reglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.reglu(input, quantizer)
-
     def srelu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.srelu(input, quantizer)
-
     def sreglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.sreglu(input, quantizer)
-
+    # SwiGLU and variants #
     def silu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.silu(input, quantizer)
-
     def swiglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.swiglu(input, quantizer)
-
     def clamped_swiglu(
         self,
         input: torch.Tensor,
@@ -314,47 +230,39 @@ class HygonBackend(TEFLBackendBase):
     ) -> Any:
         tex = self._get_tex()
         return tex.clamped_swiglu(input, quantizer, limit, alpha)
-
+    # Backward of GELU and variants #
     def dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dgelu(grad, fwd_input, quantizer)
-
     def dgeglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dgeglu(grad, fwd_input, quantizer)
-
     def dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dqgelu(grad, fwd_input, quantizer)
-    
     def dqgeglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dqgeglu(grad, fwd_input, quantizer)
-
+    # Backward of ReLU and variants #
     def drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.drelu(grad, fwd_input, quantizer)
-
     def dreglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dreglu(grad, fwd_input, quantizer)
-
     def dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dsrelu(grad, fwd_input, quantizer)
-
     def dsreglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dsreglu(grad, fwd_input, quantizer)
-
+    # Backward of SiLU and variants #
     def dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dsilu(grad, fwd_input, quantizer)
-
     def dswiglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dswiglu(grad, fwd_input, quantizer)
-
     def clamped_dswiglu(
         self,
         grad: torch.Tensor,
@@ -365,28 +273,137 @@ class HygonBackend(TEFLBackendBase):
     ) -> Any:
         tex = self._get_tex()
         return tex.clamped_dswiglu(grad, fwd_input, quantizer, limit, alpha)
-
+    # DBias + DAct fusions #
     def dbias_dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dgelu(grad, fwd_input, quantizer)
-
     def dbias_dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dsilu(grad, fwd_input, quantizer)
-
     def dbias_drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_drelu(grad, fwd_input, quantizer)
-
     def dbias_dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dqgelu(grad, fwd_input, quantizer)
-
     def dbias_dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dsrelu(grad, fwd_input, quantizer)
-
-    @_convert_dtype_params
+    # Permutation functions                                                                                                                                                                                                                                                                                             
+    def moe_permute_fwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        indices: torch.Tensor,
+        num_out_tokens: int,
+        workspace: List[torch.Tensor],
+        max_expanded_token_num: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, List[torch.Tensor]]:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_permute_fwd(input, dtype,indices,num_out_tokens,workspace,max_expanded_token_num)
+    def moe_permute_bwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+        num_tokens: int,
+        topK: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_permute_bwd(input,dtype,row_id_map,prob,num_tokens,topK)
+    def moe_unpermute_fwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+        num_tokens: int,
+        topK: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_unpermute_fwd(input,dtype,row_id_map,prob,num_tokens,topK)
+    def moe_unpermute_bwd(
+        self,
+        input_bwd: torch.Tensor,
+        input_fwd: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_unpermute_bwd(input_bwd,input_fwd,dtype,row_id_map,prob)
+    # Softmax functions
+    def scaled_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_softmax_forward(input, scale)
+    def scaled_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_softmax_backward(output_grad_, softmax_results_, scale_factor)
+    def scaled_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        mask: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_masked_softmax_forward(input, mask, scale_factor)
+    def scaled_masked_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_masked_softmax_backward(output_grad_, softmax_results_, scale_factor)
+    def scaled_upper_triang_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_upper_triang_masked_softmax_forward(input, scale_factor)
+    def scaled_upper_triang_masked_softmax_backward(
+        self,
+        output_grads_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_upper_triang_masked_softmax_backward(
+            output_grads_, softmax_results_, scale_factor
+        )
+    def scaled_aligned_causal_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_aligned_causal_masked_softmax_forward(input, scale_factor)
+    def scaled_aligned_causal_masked_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_aligned_causal_masked_softmax_backward(
+            output_grad_, softmax_results_, scale_factor
+        )
+    # Other granular functions
     def layernorm_fwd(
         self,
         input: torch.Tensor,
@@ -395,27 +412,18 @@ class HygonBackend(TEFLBackendBase):
         eps: float,
         ln_out: Optional[torch.Tensor],
         quantizer: Any,
-        otype: torch.dtype,
+        otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = input.shape
-        if input.ndim > 2:
-            input = input.view(-1, input.shape[-1])
-
-        y, mu, rsigma = tex.layernorm_fwd(
+        otype = tex.DType(int(otype)) if otype is not None else None
+        return tex.layernorm_fwd(
             input, weight, bias, eps, ln_out, quantizer, otype, sm_margin, zero_centered_gamma
         )
-
-        if len(orig_shape) > 2:
-            y = y.view(*orig_shape)
-        return y, mu, rsigma
-
     def layernorm_bwd(
         self,
-        dy: torch.Tensor,
+        dz: torch.Tensor,
         x: torch.Tensor,
         mu: torch.Tensor,
         rsigma: torch.Tensor,
@@ -424,19 +432,9 @@ class HygonBackend(TEFLBackendBase):
         zero_centered_gamma: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = dy.shape
-        if dy.ndim > 2:
-            dy = dy.view(-1, dy.shape[-1])
-            x = x.view(-1, x.shape[-1])
-
-        dx, dgamma, dbeta = tex.layernorm_bwd(dy, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma)
-
-        if len(orig_shape) > 2:
-            dx = dx.view(*orig_shape)
-        return dx, dgamma, dbeta
-
-    @_convert_dtype_params
+        return tex.layernorm_bwd(
+            dz, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma
+        )
     def rmsnorm_fwd(
         self,
         input: torch.Tensor,
@@ -444,52 +442,38 @@ class HygonBackend(TEFLBackendBase):
         eps: float,
         ln_out: Optional[torch.Tensor],
         quantizer: Any,
-        otype: torch.dtype,
+        otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = input.shape
-        if input.ndim > 2:
-            input = input.view(-1, input.shape[-1])
-
-        y, y_quant, rsigma = tex.rmsnorm_fwd(
+        otype = tex.DType(int(otype)) if otype is not None else None
+        return tex.rmsnorm_fwd(
             input, weight, eps, ln_out, quantizer, otype, sm_margin, zero_centered_gamma
         )
-
-        if len(orig_shape) > 2:
-            y = y.view(*orig_shape)
-            if y_quant is not None:
-                y_quant = y_quant.view(*orig_shape)
-        return y, y_quant, rsigma
-
     def rmsnorm_bwd(
         self,
-        dy: torch.Tensor,
+        dz: torch.Tensor,
         x: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
         sm_margin: int = 0,
         zero_centered_gamma: bool = False,
-        eps: float = 1e-5,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = dy.shape
-        if dy.ndim > 2:
-            dy = dy.view(-1, dy.shape[-1])
-            x = x.view(-1, x.shape[-1])
-
-        dx, dw = tex.rmsnorm_bwd(dy, x, rsigma, gamma, sm_margin, zero_centered_gamma)
-
-        if len(orig_shape) > 2:
-            dx = dx.view(*orig_shape)
-        return dx, dw
-
-    def rmsnorm_bwd_add(self, *args, **kwargs) -> Any:
+        return tex.rmsnorm_bwd(dz, x, rsigma, gamma, sm_margin, zero_centered_gamma)
+    def rmsnorm_bwd_add(
+        self,
+        dz: torch.Tensor,
+        x: torch.Tensor,
+        add: torch.Tensor,
+        rsigma: torch.Tensor,
+        gamma: torch.Tensor,
+        sm_margin: int = 0,
+        zero_centered_gamma: bool = False,
+    ) -> Any:
         tex = self._get_tex()
-        return tex.rmsnorm_bwd_add(*args, **kwargs)
+        return tex.rmsnorm_bwd_add(dz, x, add, rsigma, gamma, sm_margin, zero_centered_gamma)
 
     def multi_tensor_quantize(
         self,
@@ -498,7 +482,6 @@ class HygonBackend(TEFLBackendBase):
     ) -> List[Any]:
         tex = self._get_tex()
         return tex.multi_tensor_quantize(tensor_list, quantizer_list)
-
     def split_quantize(
         self,
         tensor: torch.Tensor,
@@ -507,258 +490,86 @@ class HygonBackend(TEFLBackendBase):
     ) -> List[Any]:
         tex = self._get_tex()
         return tex.split_quantize(tensor, split_sections, quantizer_list)
-
-    def moe_permute_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.moe_permute_fwd(*args, **kwargs)
-
-    def moe_permute_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.moe_permute_bwd(*args, **kwargs)
-
-    def moe_unpermute_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.moe_unpermute_fwd(*args, **kwargs)
-
-    def moe_unpermute_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.moe_unpermute_bwd(*args, **kwargs)
-
-    def scaled_softmax_forward(self, input: torch.Tensor, scale: float) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_softmax_forward(input, scale)
-
-    def scaled_softmax_backward(
+    def te_general_grouped_gemm(
         self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
+        A: torch.Tensor,
+        transa: bool,
+        B: torch.Tensor,
+        transb: bool,
+        D: Optional[List[torch.Tensor]],
+        D_type: DType,
+        m_splits: List[int],
+        bias: List[torch.Tensor],
+        bias_type: DType,
+        single_output: bool,
+        pre_gelu_out: List[torch.Tensor],
+        grad: bool,
+        workspace: List[torch.Tensor],
+        workspaceSizes: int,
+        accumulate: bool,
+        use_split_accumulator: bool,
+        math_sm_count: int,
+    ) -> Optional[List[torch.Tensor]]:
         tex = self._get_tex()
-        return tex.scaled_softmax_backward(output_grad, softmax_output, scale)
-
-    def scaled_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        mask: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_masked_softmax_forward(input, mask, scale)
-
-    def scaled_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_masked_softmax_backward(output_grad, softmax_output, scale)
-
-    def scaled_upper_triang_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_upper_triang_masked_softmax_forward(input, scale)
-
-    def scaled_upper_triang_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_upper_triang_masked_softmax_backward(output_grad, softmax_output, scale)
-
-    def scaled_aligned_causal_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_aligned_causal_masked_softmax_forward(input, scale)
-
-    def scaled_aligned_causal_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_aligned_causal_masked_softmax_backward(output_grad, softmax_output, scale)
-
-    def get_fused_attn_backend(self, *args, **kwargs) -> int:
-        raise NotImplementedError("get_fused_attn_backend - not implemented in hygon backend")
-
-    def fused_attn_fwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_attn_fwd - not implemented in hygon backend")
-
-    def fused_attn_bwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("fused_attn_bwd - not implemented in hygon backend")
-
-    def fa_prepare_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fa_prepare_fwd(*args, **kwargs)
-
-    def fa_prepare_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fa_prepare_bwd(*args, **kwargs)
-
-    def copy_to_kv_cache(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.copy_to_kv_cache(*args, **kwargs)
-
-    def convert_thd_to_bshd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.convert_thd_to_bshd(*args, **kwargs)
-
-    def convert_bshd_to_thd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.convert_bshd_to_thd(*args, **kwargs)
-
-    def fused_rope_forward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_rope_forward(*args, **kwargs)
-
-    def fused_rope_backward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_rope_backward(*args, **kwargs)
-
-    def fused_qkv_rope_forward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_qkv_rope_forward(*args, **kwargs)
-
-    def fused_qkv_rope_backward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_qkv_rope_backward(*args, **kwargs)
-
-    def fused_topk_with_score_function_fwd(
-        self,
-        logits: torch.Tensor,
-        topk: int,
-        use_pre_softmax: bool,
-        num_groups: int,
-        group_topk: int,
-        scaling_factor: float,
-        score_function: Any,
-        expert_bias: Optional[torch.Tensor],
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_topk_with_score_function_fwd(
-            logits, topk, use_pre_softmax, num_groups, group_topk,
-            scaling_factor, score_function, expert_bias
+        D_type = tex.DType(int(D_type)) if D_type is not None else None
+        bias_type = tex.DType(int(bias_type)) if bias_type is not None else None
+        return tex.te_general_grouped_gemm(
+            A, transa, B, transb, D, D_type, m_splits, bias, bias_type,
+            single_output, pre_gelu_out, grad, workspace, workspaceSizes,
+            accumulate, use_split_accumulator, math_sm_count
         )
-
-    def fused_topk_with_score_function_bwd(
-        self,
-        num_tokens: int,
-        num_experts: int,
-        routing_map: torch.Tensor,
-        intermediate_output: torch.Tensor,
-        grad_probs: torch.Tensor,
-        topk: int,
-        use_pre_softmax: bool,
-        scaling_factor: float,
-        score_function: Any,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_topk_with_score_function_bwd(
-            num_tokens, num_experts, routing_map, intermediate_output,
-            grad_probs, topk, use_pre_softmax, scaling_factor, score_function
-        )
-
-    def fused_score_for_moe_aux_loss_fwd(
-        self,
-        logits: torch.Tensor,
-        topk: int,
-        score_function: Any,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_score_for_moe_aux_loss_fwd(logits, topk, score_function)
-
-    def fused_score_for_moe_aux_loss_bwd(
-        self,
-        num_tokens: int,
-        num_experts: int,
-        intermediate_output: torch.Tensor,
-        grad_scores: torch.Tensor,
-        topk: int,
-        score_function: Any,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_score_for_moe_aux_loss_bwd(
-            num_tokens, num_experts, intermediate_output, grad_scores, topk, score_function
-        )
-
-    def fused_moe_aux_loss_fwd(
-        self,
-        probs: torch.Tensor,
-        tokens_per_expert: torch.Tensor,
-        total_num_tokens: int,
-        num_experts: int,
-        num_rows: int,
-        num_cols: int,
-        topk: int,
-        coeff: float,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_moe_aux_loss_fwd(
-            probs, tokens_per_expert, total_num_tokens, num_experts,
-            num_rows, num_cols, topk, coeff
-        )
-
-    def fused_moe_aux_loss_bwd(
-        self,
-        Const_buf: torch.Tensor,
-        tokens_per_expert: torch.Tensor,
-        num_rows: int,
-        num_cols: int,
-        grad_aux_loss: torch.Tensor,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_moe_aux_loss_bwd(
-            Const_buf, tokens_per_expert, num_rows, num_cols, grad_aux_loss
-        )
-
-    def dropout_fwd(
-        self,
-        input: torch.Tensor,
-        dropout_probability: float,
-        out: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        tex = self._get_tex()
-        return tex.dropout_fwd(input, dropout_probability, out)
-
-    def dropout_bwd(
-        self,
-        grad_output: torch.Tensor,
-        mask: torch.Tensor,
-        dropout_probability: float,
-        grad_input: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.dropout_bwd(grad_output, mask, dropout_probability, grad_input)
-
     def fp8_transpose(
         self,
         input: torch.Tensor,
-        dtype: Any,
-        *,
-        out: torch.Tensor,
-    ) -> None:
+        otype: DType,
+        output: Optional[torch.Tensor],
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        tex.fp8_transpose(input, dtype, out=out)
-
+        otype = tex.DType(int(otype)) if otype is not None else None
+        return tex.fp8_transpose(input, otype, output)
     def swap_first_dims(
         self,
         tensor: torch.Tensor,
-        *,
-        out: torch.Tensor,
-    ) -> None:
+        out: Optional[torch.Tensor],
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        tex.swap_first_dims(tensor, out=out)
+        return tex.swap_first_dims(tensor, out)
+    def get_fused_attn_backend(
+        self,
+        is_training: bool,
+        q_dtype: DType,
+        kv_dtype: DType,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        p_dropout: float,
+        num_attn_heads: int,
+        num_gqa_groups: int,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        head_dim_qk: int,
+        head_dim_v: int,
+        window_size_left: int,
+        window_size_right: int,
+        return_max_logit: bool,
+    ) -> NVTE_Fused_Attn_Backend:
+        tex = self._get_tex()
+
+        q_dtype = tex.DType(int(q_dtype)) if q_dtype is not None else None
+        kv_dtype = tex.DType(int(kv_dtype)) if kv_dtype is not None else None
+        qkv_layout = tex.NVTE_QKV_Layout(int(qkv_layout)) if qkv_layout is not None else None
+        bias_type = tex.NVTE_Bias_Type(int(bias_type)) if bias_type is not None else None
+        attn_mask_type = tex.NVTE_Mask_Type(int(attn_mask_type)) if attn_mask_type is not None else None
+        softmax_type = tex.NVTE_Softmax_Type(int(softmax_type)) if softmax_type is not None else None
+
+        result = tex.get_fused_attn_backend(
+            is_training, q_dtype, kv_dtype, qkv_layout, bias_type,
+            attn_mask_type, softmax_type, p_dropout, num_attn_heads,
+            num_gqa_groups, max_seqlen_q, max_seqlen_kv, head_dim_qk,
+            head_dim_v, window_size_left, window_size_right, return_max_logit
+        )
+        return NVTE_Fused_Attn_Backend(result)
 
     def compute_amax(
         self,
@@ -766,12 +577,22 @@ class HygonBackend(TEFLBackendBase):
         amax: torch.Tensor,
     ) -> None:
         tex = self._get_tex()
-        tex.compute_amax(input, amax)
-
-    def fused_amax_and_scale_update_after_reduction(self, *args, **kwargs) -> None:
+        return tex.compute_amax(input, amax)
+    def fused_amax_and_scale_update_after_reduction(
+        self,
+        amax_reduction_buffer: torch.Tensor,
+        amax_histories: List[torch.Tensor],
+        scales: List[torch.Tensor],
+        amax_compute_algo: str,
+        fp8_dtype: DType,
+        margin: float,
+    ) -> None:
         tex = self._get_tex()
-        tex.fused_amax_and_scale_update_after_reduction(*args, **kwargs)
-
+        fp8_dtype = tex.DType(int(fp8_dtype)) if fp8_dtype is not None else None
+        return tex.fused_amax_and_scale_update_after_reduction(
+            amax_reduction_buffer, amax_histories, scales,
+            amax_compute_algo, fp8_dtype, margin
+        )
     def fp8_block_scaling_compute_partial_amax(
         self,
         tensor: torch.Tensor,
@@ -782,8 +603,9 @@ class HygonBackend(TEFLBackendBase):
         block_len: int,
     ) -> None:
         tex = self._get_tex()
-        tex.fp8_block_scaling_compute_partial_amax(tensor, amax, h, w, start_offset, block_len)
-
+        return tex.fp8_block_scaling_compute_partial_amax(
+            tensor, amax, h, w, start_offset, block_len
+        )
     def fp8_block_scaling_partial_cast(
         self,
         inp: torch.Tensor,
@@ -793,70 +615,555 @@ class HygonBackend(TEFLBackendBase):
         w: int,
         start_offset: int,
         block_len: int,
-        out_dtype: Any,
+        out_dtype: DType,
     ) -> None:
         tex = self._get_tex()
-        tex.fp8_block_scaling_partial_cast(inp, out, scale, h, w, start_offset, block_len, out_dtype)
-
-    def fused_multi_row_padding(self, *args, **kwargs) -> Any:
+        out_dtype = tex.DType(int(out_dtype)) if out_dtype is not None else None
+        return tex.fp8_block_scaling_partial_cast(
+            inp, out, scale, h, w, start_offset, block_len, out_dtype
+        )
+    def fused_multi_row_padding(
+        self,
+        input: torch.Tensor,
+        output: torch.Tensor,
+        input_row_list: List[int],
+        padded_input_row_list: List[int],
+    ) -> None:
         tex = self._get_tex()
-        return tex.fused_multi_row_padding(*args, **kwargs)
-
-    def fused_multi_row_unpadding(self, *args, **kwargs) -> Any:
+        return tex.fused_multi_row_padding(
+            input, output, input_row_list, padded_input_row_list
+        )
+    def fused_multi_row_unpadding(
+        self,
+        input: torch.Tensor,
+        output: torch.Tensor,
+        input_row_list: List[int],
+        unpadded_input_row_list: List[int],
+    ) -> None:
         tex = self._get_tex()
-        return tex.fused_multi_row_unpadding(*args, **kwargs)
+        return tex.fused_multi_row_unpadding(
+            input, output, input_row_list, unpadded_input_row_list
+        )
 
+    # attention kernels
+    def fa_prepare_fwd(
+        self,
+        qkvi: torch.Tensor,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fa_prepare_fwd(qkvi)
+    def fa_prepare_bwd(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fa_prepare_bwd(q, k, v)
+    def fused_attn_fwd(
+        self,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        is_training: bool,
+        attn_scale: float,
+        p_dropout: float,
+        set_zero: bool,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        window_size: List[int],
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_kv: torch.Tensor,
+        Q: Any,
+        K: Any,
+        V: Any,
+        fake_dtype: torch.dtype,
+        cu_seqlens_q_padded: Optional[torch.Tensor],
+        cu_seqlens_kv_padded: Optional[torch.Tensor],
+        page_table_k: Optional[torch.Tensor],
+        page_table_v: Optional[torch.Tensor],
+        s_quantizer: Any,
+        o_quantizer: Any,
+        Bias: Optional[torch.Tensor],
+        SoftmaxOffset: Optional[torch.Tensor],
+        rng_gen: Optional[torch.Generator],
+        rng_elts_per_thread: int,
+        return_max_logit: bool,
+    ) -> List[Any]:
+        tex = self._get_tex()
+
+        qkv_layout = tex.NVTE_QKV_Layout(int(qkv_layout)) if qkv_layout is not None else None
+        bias_type = tex.NVTE_Bias_Type(int(bias_type)) if bias_type is not None else None
+        attn_mask_type = tex.NVTE_Mask_Type(int(attn_mask_type)) if attn_mask_type is not None else None
+        softmax_type = tex.NVTE_Softmax_Type(int(softmax_type)) if softmax_type is not None else None
+
+        return tex.fused_attn_fwd(
+            max_seqlen_q,
+            max_seqlen_kv,
+            is_training,
+            attn_scale,
+            p_dropout,
+            set_zero,
+            qkv_layout,
+            bias_type,
+            attn_mask_type,
+            softmax_type,
+            window_size,
+            cu_seqlens_q,
+            cu_seqlens_kv,
+            Q,
+            K,
+            V,
+            fake_dtype,
+            cu_seqlens_q_padded,
+            cu_seqlens_kv_padded,
+            page_table_k,
+            page_table_v,
+            s_quantizer,
+            o_quantizer,
+            Bias,
+            SoftmaxOffset,
+            rng_gen,
+            rng_elts_per_thread,
+            return_max_logit
+        )
+    def fused_attn_bwd(
+        self,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        attn_scale: float,
+        p_dropout: float,
+        set_zero: bool,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        window_size: List[int],
+        deterministic: bool,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_kv: torch.Tensor,
+        Q: Any,
+        K: Any,
+        V: Any,
+        O: Any,
+        dO: Any,
+        fake_dtype: torch.dtype,
+        dqkv_type: DType,
+        Aux_CTX_Tensors: List[torch.Tensor],
+        cu_seqlens_q_padded: Optional[torch.Tensor],
+        cu_seqlens_kv_padded: Optional[torch.Tensor],
+        s_quantizer: Any,
+        dp_quantizer: Any,
+        dqkv_quantizer: Any,
+    ) -> List[Any]:
+        tex = self._get_tex()
+
+        qkv_layout = tex.NVTE_QKV_Layout(int(qkv_layout)) if qkv_layout is not None else None
+        bias_type = tex.NVTE_Bias_Type(int(bias_type)) if bias_type is not None else None
+        attn_mask_type = tex.NVTE_Mask_Type(int(attn_mask_type)) if attn_mask_type is not None else None
+        softmax_type = tex.NVTE_Softmax_Type(int(softmax_type)) if softmax_type is not None else None
+        dqkv_type = tex.DType(int(dqkv_type)) if dqkv_type is not None else None
+
+        return tex.fused_attn_bwd(
+            max_seqlen_q,
+            max_seqlen_kv,
+            attn_scale,
+            p_dropout,
+            set_zero,
+            qkv_layout,
+            bias_type,
+            attn_mask_type,
+            softmax_type,
+            window_size,
+            deterministic,
+            cu_seqlens_q,
+            cu_seqlens_kv,
+            Q,
+            K,
+            V,
+            O,
+            dO,
+            fake_dtype,
+            dqkv_type,
+            Aux_CTX_Tensors,
+            cu_seqlens_q_padded,
+            cu_seqlens_kv_padded,
+            s_quantizer,
+            dp_quantizer,
+            dqkv_quantizer
+        )
+    def copy_to_kv_cache(
+        self,
+        new_k: torch.Tensor,
+        new_v: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        page_table: torch.Tensor,
+        cu_new_lens: torch.Tensor,
+        cu_cached_lens: torch.Tensor,
+        qkv_format: NVTE_QKV_Format,
+        b: int,
+        max_ctx_len: int,
+        max_seq_len: int,
+        max_pages_per_seq: int,
+        is_non_paged: bool,
+    ) -> None:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.copy_to_kv_cache(
+            new_k,
+            new_v,
+            k_cache,
+            v_cache,
+            page_table,
+            cu_new_lens,
+            cu_cached_lens,
+            qkv_format,
+            b,
+            max_ctx_len,
+            max_seq_len,
+            max_pages_per_seq,
+            is_non_paged
+        )
+    def convert_thd_to_bshd(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        b: int,
+        max_seq_len: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.convert_thd_to_bshd(tensor, cu_seqlens, b, max_seq_len)
+    def convert_bshd_to_thd(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        t: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.convert_bshd_to_thd(tensor, cu_seqlens, t)
+
+    # fused apply rope
+    def fused_rope_forward(
+        self,
+        input: torch.Tensor,
+        freqs: torch.Tensor,
+        start_positions: Optional[torch.Tensor],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cu_seqlens: Optional[torch.Tensor],
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_rope_forward(
+            input, freqs, start_positions, qkv_format,
+            interleaved, cu_seqlens, cp_size, cp_rank
+        )
+    def fused_rope_backward(
+        self,
+        output_grads: torch.Tensor,
+        freqs: torch.Tensor,
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cu_seqlens: Optional[torch.Tensor],
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_rope_backward(
+            output_grads, freqs, qkv_format,
+            interleaved, cu_seqlens, cp_size, cp_rank
+        )
+    def fused_qkv_rope_forward(
+        self,
+        qkv_input: torch.Tensor,
+        q_freqs: torch.Tensor,
+        k_freqs: torch.Tensor,
+        start_positions: Optional[torch.Tensor],
+        qkv_split_arg_list: List[int],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cp_size: int,
+        cp_rank: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_qkv_rope_forward(
+            qkv_input, q_freqs, k_freqs, start_positions,
+            qkv_split_arg_list, qkv_format, interleaved,
+            cp_size, cp_rank
+        )
+    def fused_qkv_rope_backward(
+        self,
+        q_grad_out: torch.Tensor,
+        k_grad_out: torch.Tensor,
+        v_grad_out: torch.Tensor,
+        q_freqs: torch.Tensor,
+        k_freqs: torch.Tensor,
+        qkv_split_arg_list: List[int],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_qkv_rope_backward(
+            q_grad_out, k_grad_out, v_grad_out,
+            q_freqs, k_freqs, qkv_split_arg_list,
+            qkv_format, interleaved, cp_size, cp_rank
+        )
+
+    # fused router
+    def fused_topk_with_score_function_fwd(
+        self,
+        logits: torch.Tensor,
+        topk: int,
+        use_pre_softmax: bool,
+        num_groups: Optional[int],
+        group_topk: Optional[int],
+        scaling_factor: Optional[float],
+        score_function: str,
+        expert_bias: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.fused_topk_with_score_function_fwd(
+            logits,
+            topk,
+            use_pre_softmax,
+            num_groups,
+            group_topk,
+            scaling_factor,
+            score_function,
+            expert_bias,
+        )
+    def fused_topk_with_score_function_bwd(
+        self,
+        num_tokens: int,
+        num_experts: int,
+        routing_map: torch.Tensor,
+        intermediate_output: torch.Tensor,
+        grad_probs: torch.Tensor,
+        topk: int,
+        use_pre_softmax: bool,
+        scaling_factor: Optional[float],
+        score_function: str,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fused_topk_with_score_function_bwd(
+            num_tokens,
+            num_experts,
+            routing_map,
+            intermediate_output,
+            grad_probs,
+            topk,
+            use_pre_softmax,
+            scaling_factor,
+            score_function,
+        )
+    def fused_score_for_moe_aux_loss_fwd(
+        self,
+        logits: torch.Tensor,
+        topk: int,
+        score_function: str,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.fused_score_for_moe_aux_loss_fwd(
+            logits,
+            topk,
+            score_function,
+        )
+    def fused_score_for_moe_aux_loss_bwd(
+        self,
+        num_tokens: int,
+        num_experts: int,
+        intermediate_output: torch.Tensor,
+        grad_scores: torch.Tensor,
+        topk: int,
+        score_function: str,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fused_score_for_moe_aux_loss_bwd(
+            num_tokens,
+            num_experts,
+            intermediate_output,
+            grad_scores,
+            topk,
+            score_function,
+        )
+    def fused_moe_aux_loss_fwd(
+        self,
+        probs: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        total_num_tokens: int,
+        num_experts: int,
+        num_rows: int,
+        num_cols: int,
+        topk: int,
+        coeff: float,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.fused_moe_aux_loss_fwd(
+            probs,
+            tokens_per_expert,
+            total_num_tokens,
+            num_experts,
+            num_rows,
+            num_cols,
+            topk,
+            coeff,
+        )
+    def fused_moe_aux_loss_bwd(
+        self,
+        Const_buf: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        num_rows: int,
+        num_cols: int,
+        grad_aux_loss: torch.Tensor,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fused_moe_aux_loss_bwd(Const_buf, tokens_per_expert, num_rows, num_cols, grad_aux_loss)
+
+    # Dropout
+    def dropout_fwd(
+        self,
+        input: torch.Tensor,
+        dropout_probability: float,
+        out: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.dropout_fwd(input, dropout_probability, out)
+    def dropout_bwd(
+        self,
+        grad_output: torch.Tensor,
+        mask: torch.Tensor,
+        dropout_probability: float,
+        grad_input: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.dropout_bwd(grad_output, mask, dropout_probability, grad_input)
+
+    # Misc
     def get_cublasLt_version(self) -> int:
         tex = self._get_tex()
         return tex.get_cublasLt_version()
-
     def get_cudnn_version(self) -> int:
         tex = self._get_tex()
         return tex.get_cudnn_version()
-
     def get_num_cublas_streams(self) -> int:
         tex = self._get_tex()
         return tex.get_num_cublas_streams()
 
-    def thd_read_half_tensor(self, *args, **kwargs) -> Any:
+    # Support THD format for Context Parallel
+    def thd_read_half_tensor(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        half_idx: int,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.thd_read_half_tensor(*args, **kwargs)
-
-    def thd_second_half_lse_correction(self, *args, **kwargs) -> Any:
+        return tex.thd_read_half_tensor(tensor, cu_seqlens, half_idx)
+    def thd_second_half_lse_correction(
+        self,
+        lse: torch.Tensor,
+        lse_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        lse_packed: bool,
+    ) -> None:
         tex = self._get_tex()
-        return tex.thd_second_half_lse_correction(*args, **kwargs)
-
-    def thd_read_second_half_lse(self, *args, **kwargs) -> Any:
+        return tex.thd_second_half_lse_correction(
+            lse, lse_per_step, cu_seqlens, lse_packed
+        )
+    def thd_read_second_half_lse(
+        self,
+        lse: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        lse_packed: bool,
+        second_half_lse_seqlen: int,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.thd_read_second_half_lse(*args, **kwargs)
-
-    def thd_out_correction(self, *args, **kwargs) -> Any:
+        return tex.thd_read_second_half_lse(
+            lse, cu_seqlens, lse_packed, second_half_lse_seqlen
+        )
+    def thd_out_correction(
+        self,
+        out: torch.Tensor,
+        out_per_step: torch.Tensor,
+        lse: torch.Tensor,
+        lse_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        only_second_half: bool,
+        lse_packed: bool,
+    ) -> None:
         tex = self._get_tex()
-        return tex.thd_out_correction(*args, **kwargs)
-
-    def thd_grad_correction(self, *args, **kwargs) -> Any:
+        return tex.thd_out_correction(
+            out, out_per_step, lse, lse_per_step,
+            cu_seqlens, only_second_half, lse_packed
+        )
+    def thd_grad_correction(
+        self,
+        grad: torch.Tensor,
+        grad_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        first_half: str,
+        second_half: str,
+    ) -> None:
         tex = self._get_tex()
-        return tex.thd_grad_correction(*args, **kwargs)
-
-    def thd_get_partitioned_indices(self, *args, **kwargs) -> Any:
+        return tex.thd_grad_correction(
+            grad, grad_per_step, cu_seqlens,
+            first_half, second_half
+        )
+    def thd_get_partitioned_indices(
+        self,
+        cu_seqlens: torch.Tensor,
+        total_tokens: int,
+        world_size: int,
+        rank: int,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.thd_get_partitioned_indices(*args, **kwargs)
+        return tex.thd_get_partitioned_indices(
+            cu_seqlens, total_tokens, world_size, rank
+        )
 
-    def init_nvshmem_backend(self, *args, **kwargs) -> None:
-        raise NotImplementedError("init_nvshmem_backend - not implemented in hygon backend")
-
-    def create_nvshmem_tensor(self, *args, **kwargs) -> torch.Tensor:
-        raise NotImplementedError("create_nvshmem_tensor - not implemented in hygon backend")
-
-    def nvshmem_send_on_current_stream(self, *args, **kwargs) -> None:
-        raise NotImplementedError("nvshmem_send_on_current_stream - not implemented in hygon backend")
-
-    def nvshmem_wait_on_current_stream(self, *args, **kwargs) -> None:
-        raise NotImplementedError("nvshmem_wait_on_current_stream - not implemented in hygon backend")
-
+    # nvshmem functions
+    def init_nvshmem_backend(
+        self,
+        process_group: Any,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.init_nvshmem_backend(process_group)
+    def create_nvshmem_tensor(
+        self,
+        shape: List[int],
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.create_nvshmem_tensor(shape, dtype)
+    def nvshmem_send_on_current_stream(
+        self,
+        src: torch.Tensor,
+        dst: torch.Tensor,
+        peer: int,
+        signal: torch.Tensor,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.nvshmem_send_on_current_stream(src, dst, peer, signal)
+    def nvshmem_wait_on_current_stream(
+        self,
+        signal: torch.Tensor,
+        wait_kind: str,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.nvshmem_wait_on_current_stream(signal, wait_kind)
     def nvshmem_finalize(self) -> None:
-        raise NotImplementedError("nvshmem_finalize - not implemented in hygon backend")
+        tex = self._get_tex()
+        return tex.nvshmem_finalize()
 
+    # multi-tensor functions
     def multi_tensor_scale(
         self,
         chunk_size: int,
@@ -865,98 +1172,195 @@ class HygonBackend(TEFLBackendBase):
         scale: float,
     ) -> None:
         tex = self._get_tex()
-        tex.multi_tensor_scale(chunk_size, noop_flag, tensor_lists, scale)
-
+        return tex.multi_tensor_scale(chunk_size, noop_flag, tensor_lists, scale)
     def multi_tensor_l2norm(
         self,
         chunk_size: int,
         noop_flag: torch.Tensor,
         tensor_lists: List[List[torch.Tensor]],
-        per_tensor: bool = False,
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
+        per_tensor: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
         return tex.multi_tensor_l2norm(chunk_size, noop_flag, tensor_lists, per_tensor)
-
     def multi_tensor_unscale_l2norm(
         self,
         chunk_size: int,
         noop_flag: torch.Tensor,
         tensor_lists: List[List[torch.Tensor]],
-        scale: torch.Tensor,
-        per_tensor: bool = False,
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
+        inv_scale: torch.Tensor,
+        per_tensor: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-        return tex.multi_tensor_unscale_l2norm(chunk_size, noop_flag, tensor_lists, scale, per_tensor)
-
+        return tex.multi_tensor_unscale_l2norm(
+            chunk_size, noop_flag, tensor_lists, inv_scale, per_tensor
+        )
     def multi_tensor_adam(
         self,
-        chunk_size: int = None,
-        noop_flag: torch.Tensor = None,
-        tensor_lists: List[List[torch.Tensor]] = None,
-        lr: float = None,
-        beta1: float = None,
-        beta2: float = None,
-        eps: float = None,
-        step: int = None,
-        mode: int = None,
-        bias_correction: int = None,
-        weight_decay: float = None,
-    ):
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
         tex = self._get_tex()
-        if chunk_size is None:
-            return tex.multi_tensor_adam
-        tex.multi_tensor_adam(
-            chunk_size, noop_flag, tensor_lists, lr, beta1, beta2,
-            eps, step, mode, bias_correction, weight_decay
+        return tex.multi_tensor_adam(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay
+        )
+    def multi_tensor_adam_param_remainder(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_adam_param_remainder(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay
+        )
+    def multi_tensor_adam_fp8(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        fp8_dtype: DType,
+    ) -> None:
+        tex = self._get_tex()
+        fp8_dtype = tex.DType(int(fp8_dtype)) if fp8_dtype is not None else None
+        return tex.multi_tensor_adam_fp8(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
+            fp8_dtype
+        )
+    def multi_tensor_adam_capturable(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: torch.Tensor,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: torch.Tensor,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        inv_scale: torch.Tensor,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_adam_capturable(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
+            inv_scale
+        )
+    def multi_tensor_adam_capturable_master(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: torch.Tensor,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: torch.Tensor,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        inv_scale: torch.Tensor,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_adam_capturable_master(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
+            inv_scale
+        )
+    def multi_tensor_sgd(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        wd: float,
+        momentum: float,
+        dampening: float,
+        lr: float,
+        nesterov: bool,
+        first_run: bool,
+        wd_after_momentum: bool,
+        scale: float,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_sgd(
+            chunk_size, noop_flag, tensor_lists,
+            wd, momentum, dampening,
+            lr, nesterov, first_run,
+            wd_after_momentum, scale
+        )
+    def multi_tensor_compute_scale_and_scale_inv(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        max_fp8: float,
+        force_pow_2_scales: bool,
+        epsilon: float,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_compute_scale_and_scale_inv(
+            chunk_size, noop_flag, tensor_lists,
+            max_fp8, force_pow_2_scales, epsilon
         )
 
-    def multi_tensor_adam_param_remainder(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_param_remainder(*args, **kwargs)
-
-    def multi_tensor_adam_fp8(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_fp8(*args, **kwargs)
-
-    def multi_tensor_adam_capturable(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_capturable(*args, **kwargs)
-
-    def multi_tensor_adam_capturable_master(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_capturable_master(*args, **kwargs)
-
-    def multi_tensor_sgd(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_sgd(*args, **kwargs)
-
-    def multi_tensor_compute_scale_and_scale_inv(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_compute_scale_and_scale_inv(*args, **kwargs)
-
+    # Comm+GEMM Overlap
     def bulk_overlap_ag_with_external_gemm(
         self,
-        allgather_communicator: Any,
+        allgather_communicator: CommOverlap,
         send_stream: Any,
         recv_stream: Any,
     ) -> Any:
         tex = self._get_tex()
         return tex.bulk_overlap_ag_with_external_gemm(allgather_communicator, send_stream, recv_stream)
 
+############## class func #################################
+    def get_flash_attention_class(self):
+        from .flash_attention import FlashAttentionHYGON
+        return FlashAttentionHYGON
     def create_fp8_tensor_meta(self) -> FP8TensorMeta:
         tex = self._get_tex()
         return tex.FP8TensorMeta()
-
     def create_comm_overlap_helper(
         self,
         world_group: Optional[Any] = None,
         intra_node_group: Optional[Any] = None,
-    ) -> Any:
+    ) -> "CommOverlapHelper":
         tex = self._get_tex()
-        if world_group is None:
-            return tex.CommOverlapHelper()
         return tex.CommOverlapHelper(world_group, intra_node_group)
-
     def create_comm_overlap(
         self,
         buffer_shape: List[int],
@@ -972,7 +1376,7 @@ class HygonBackend(TEFLBackendBase):
         set_sm_margin: bool = True,
         atomic_gemm: bool = False,
         rs_overlap_first_gemm: bool = False,
-    ) -> Any:
+    ) -> "CommOverlap":
         tex = self._get_tex()
         return tex.CommOverlap(
             buffer_shape, buffer_dtype, helper, tp_size,
@@ -980,7 +1384,6 @@ class HygonBackend(TEFLBackendBase):
             gemm_priority, comm_priority, num_comm_sm,
             set_sm_margin, atomic_gemm, rs_overlap_first_gemm
         )
-
     def create_comm_overlap_p2p(
         self,
         buffer_shape: List[int],
@@ -997,7 +1400,7 @@ class HygonBackend(TEFLBackendBase):
         atomic_gemm: bool = False,
         use_ce: bool = True,
         aggregate: bool = False,
-    ) -> Any:
+    ) -> "CommOverlapP2P":
         tex = self._get_tex()
         return tex.CommOverlapP2P(
             buffer_shape, buffer_dtype, helper, tp_size, comm_type,

--- a/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
+++ b/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
@@ -148,26 +148,26 @@ class HygonBackend(TEFLBackendBase):
         self,
         input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.bgrad_quantize(input, quantizer)
 
     def generic_gemm(
         self,
         A: Any,
-        transa: bool,
+        transA: bool,
         B: Any,
-        transb: bool,
+        transB: bool,
         D: Any,
         quantizer: Any,
-        out_dtype: Optional[DType],
+        output_dtype: Optional[DType],
         bias: Optional[torch.Tensor],
         bias_type: DType,
         gelu: bool,
         gelu_in: Optional[torch.Tensor],
         grad: bool,
         workspace: torch.Tensor,
-        workspaceSize: int,
+        workspace_size: int,
         accumulate: bool,
         use_split_accumulator: bool,
         comm_overlap: Optional[Any] = None,
@@ -181,10 +181,10 @@ class HygonBackend(TEFLBackendBase):
         
         bias_type = tex.DType(int(bias_type)) if bias_type is not None else None
         comm_type = tex.CommOverlapType(int(comm_type)) if comm_type is not None else None
-        out_dtype = tex.DType(int(out_dtype)) if out_dtype is not None else None
+        output_dtype = tex.DType(int(output_dtype)) if output_dtype is not None else None
         return tex.generic_gemm(
-            A, transa, B, transb, D, quantizer, out_dtype,
-            bias, bias_type, gelu, gelu_in, grad, workspace, workspaceSize,
+            A, transA, B, transB, D, quantizer, output_dtype,
+            bias, bias_type, gelu, gelu_in, grad, workspace, workspace_size,
             accumulate, use_split_accumulator, comm_overlap, comm_type,
             extra_output, bulk_overlap, alpha, beta
         )
@@ -274,19 +274,19 @@ class HygonBackend(TEFLBackendBase):
         tex = self._get_tex()
         return tex.clamped_dswiglu(grad, fwd_input, quantizer, limit, alpha)
     # DBias + DAct fusions #
-    def dbias_dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dgelu(grad, fwd_input, quantizer)
-    def dbias_dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dsilu(grad, fwd_input, quantizer)
-    def dbias_drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_drelu(grad, fwd_input, quantizer)
-    def dbias_dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dqgelu(grad, fwd_input, quantizer)
-    def dbias_dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dsrelu(grad, fwd_input, quantizer)
     # Permutation functions                                                                                                                                                                                                                                                                                             
@@ -410,12 +410,12 @@ class HygonBackend(TEFLBackendBase):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor],
         eps: float,
-        ln_out: Optional[torch.Tensor],
+        ln_out: Any,
         quantizer: Any,
         otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> List[Any]:
         tex = self._get_tex()
         otype = tex.DType(int(otype)) if otype is not None else None
         return tex.layernorm_fwd(
@@ -428,24 +428,24 @@ class HygonBackend(TEFLBackendBase):
         mu: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.layernorm_bwd(
             dz, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma
         )
     def rmsnorm_fwd(
         self,
-        input: torch.Tensor,
-        weight: torch.Tensor,
+        input: Any,
+        weight: Any,
         eps: float,
-        ln_out: Optional[torch.Tensor],
+        ln_out: Any,
         quantizer: Any,
         otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    ) -> List[Any]:
         tex = self._get_tex()
         otype = tex.DType(int(otype)) if otype is not None else None
         return tex.rmsnorm_fwd(
@@ -457,9 +457,9 @@ class HygonBackend(TEFLBackendBase):
         x: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.rmsnorm_bwd(dz, x, rsigma, gamma, sm_margin, zero_centered_gamma)
     def rmsnorm_bwd_add(
@@ -469,9 +469,9 @@ class HygonBackend(TEFLBackendBase):
         add: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Any:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.rmsnorm_bwd_add(dz, x, add, rsigma, gamma, sm_margin, zero_centered_gamma)
 
@@ -492,9 +492,9 @@ class HygonBackend(TEFLBackendBase):
         return tex.split_quantize(tensor, split_sections, quantizer_list)
     def te_general_grouped_gemm(
         self,
-        A: torch.Tensor,
+        A: List[Any],
         transa: bool,
-        B: torch.Tensor,
+        B: List[Any],
         transb: bool,
         D: Optional[List[torch.Tensor]],
         D_type: DType,
@@ -521,12 +521,12 @@ class HygonBackend(TEFLBackendBase):
     def fp8_transpose(
         self,
         input: torch.Tensor,
-        otype: DType,
-        output: Optional[torch.Tensor],
+        dtype: DType,
+        out: Optional[torch.Tensor],
     ) -> torch.Tensor:
         tex = self._get_tex()
-        otype = tex.DType(int(otype)) if otype is not None else None
-        return tex.fp8_transpose(input, otype, output)
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.fp8_transpose(input, dtype, out)
     def swap_first_dims(
         self,
         tensor: torch.Tensor,

--- a/transformer_engine/plugin/core/backends/vendor/iluvatar/iluvatar.py
+++ b/transformer_engine/plugin/core/backends/vendor/iluvatar/iluvatar.py
@@ -176,26 +176,26 @@ class IluvatarBackend(TEFLBackendBase):
         self,
         input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.bgrad_quantize(input, quantizer)
 
     def generic_gemm(
         self,
         A: Any,
-        transa: bool,
+        transA: bool,
         B: Any,
-        transb: bool,
+        transB: bool,
         D: Any,
         quantizer: Any,
-        out_dtype: Optional[DType],
+        output_dtype: Optional[DType],
         bias: Optional[torch.Tensor],
         bias_type: DType,
         gelu: bool,
         gelu_in: Optional[torch.Tensor],
         grad: bool,
         workspace: torch.Tensor,
-        workspaceSize: int,
+        workspace_size: int,
         accumulate: bool,
         use_split_accumulator: bool,
         comm_overlap: Optional[Any] = None,
@@ -209,10 +209,10 @@ class IluvatarBackend(TEFLBackendBase):
         
         bias_type = tex.DType(int(bias_type)) if bias_type is not None else None
         comm_type = tex.CommOverlapType(int(comm_type)) if comm_type is not None else None
-        out_dtype = tex.DType(int(out_dtype)) if out_dtype is not None else None
+        output_dtype = tex.DType(int(output_dtype)) if output_dtype is not None else None
         return tex.generic_gemm(
-            A, transa, B, transb, D, quantizer, out_dtype,
-            bias, bias_type, gelu, gelu_in, grad, workspace, workspaceSize,
+            A, transA, B, transB, D, quantizer, output_dtype,
+            bias, bias_type, gelu, gelu_in, grad, workspace, workspace_size,
             accumulate, use_split_accumulator, comm_overlap, comm_type,
             extra_output, bulk_overlap, alpha, beta
         )
@@ -302,19 +302,19 @@ class IluvatarBackend(TEFLBackendBase):
         tex = self._get_tex()
         return tex.clamped_dswiglu(grad, fwd_input, quantizer, limit, alpha)
     # DBias + DAct fusions #
-    def dbias_dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dgelu(grad, fwd_input, quantizer)
-    def dbias_dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dsilu(grad, fwd_input, quantizer)
-    def dbias_drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_drelu(grad, fwd_input, quantizer)
-    def dbias_dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dqgelu(grad, fwd_input, quantizer)
-    def dbias_dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dsrelu(grad, fwd_input, quantizer)
     # Permutation functions                                                                                                                                                                                                                                                                                             
@@ -438,12 +438,12 @@ class IluvatarBackend(TEFLBackendBase):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor],
         eps: float,
-        ln_out: Optional[torch.Tensor],
+        ln_out: Any,
         quantizer: Any,
         otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> List[Any]:
         tex = self._get_tex()
         otype = tex.DType(int(otype)) if otype is not None else None
         return tex.layernorm_fwd(
@@ -456,24 +456,24 @@ class IluvatarBackend(TEFLBackendBase):
         mu: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.layernorm_bwd(
             dz, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma
         )
     def rmsnorm_fwd(
         self,
-        input: torch.Tensor,
-        weight: torch.Tensor,
+        input: Any,
+        weight: Any,
         eps: float,
-        ln_out: Optional[torch.Tensor],
+        ln_out: Any,
         quantizer: Any,
         otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    ) -> List[Any]:
         tex = self._get_tex()
         otype = tex.DType(int(otype)) if otype is not None else None
         return tex.rmsnorm_fwd(
@@ -485,9 +485,9 @@ class IluvatarBackend(TEFLBackendBase):
         x: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.rmsnorm_bwd(dz, x, rsigma, gamma, sm_margin, zero_centered_gamma)
     def rmsnorm_bwd_add(
@@ -497,9 +497,9 @@ class IluvatarBackend(TEFLBackendBase):
         add: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Any:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.rmsnorm_bwd_add(dz, x, add, rsigma, gamma, sm_margin, zero_centered_gamma)
 
@@ -520,9 +520,9 @@ class IluvatarBackend(TEFLBackendBase):
         return tex.split_quantize(tensor, split_sections, quantizer_list)
     def te_general_grouped_gemm(
         self,
-        A: torch.Tensor,
+        A: List[Any],
         transa: bool,
-        B: torch.Tensor,
+        B: List[Any],
         transb: bool,
         D: Optional[List[torch.Tensor]],
         D_type: DType,
@@ -549,12 +549,12 @@ class IluvatarBackend(TEFLBackendBase):
     def fp8_transpose(
         self,
         input: torch.Tensor,
-        otype: DType,
-        output: Optional[torch.Tensor],
+        dtype: DType,
+        out: Optional[torch.Tensor],
     ) -> torch.Tensor:
         tex = self._get_tex()
-        otype = tex.DType(int(otype)) if otype is not None else None
-        return tex.fp8_transpose(input, otype, output)
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.fp8_transpose(input, dtype, out)
     def swap_first_dims(
         self,
         tensor: torch.Tensor,

--- a/transformer_engine/plugin/core/backends/vendor/iluvatar/iluvatar.py
+++ b/transformer_engine/plugin/core/backends/vendor/iluvatar/iluvatar.py
@@ -7,8 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import math
 import torch
 
-from ....ops import TEFLBackendBase, FP8TensorMeta
-
+from ....ops import *
 
 def _load_iluvatar_libs():
     import ctypes
@@ -105,67 +104,6 @@ def _get_tex():
     import transformer_engine_iluvatar.pytorch.ixte_torch
     return transformer_engine_iluvatar.pytorch.ixte_torch
 
-def _torch_dtype_to_te_dtype(torch_dtype, tex_module):
-    if torch_dtype is None:
-        return None
-
-    NativeDType = tex_module.DType
-    if type(torch_dtype).__name__ == 'DType' and type(torch_dtype).__module__ == 'transformer_engine_iluvatar.pytorch.ixte_torch':
-        return torch_dtype
-
-    if hasattr(torch_dtype, 'name') and hasattr(torch_dtype, 'value'):
-        from transformer_engine.plugin.core.ops import DType as PyDType
-        if isinstance(torch_dtype, PyDType):
-            dtype_name = torch_dtype.name
-            if hasattr(NativeDType, dtype_name):
-                return getattr(NativeDType, dtype_name)
-
-    dtype_map = {
-        torch.uint8: NativeDType.kByte,
-        torch.float8_e4m3fn: NativeDType.kFloat8E4M3,
-        torch.float8_e5m2: NativeDType.kFloat8E5M2,
-        torch.int32: NativeDType.kInt32,
-        torch.float32: NativeDType.kFloat32,
-        torch.half: NativeDType.kFloat16,
-        torch.bfloat16: NativeDType.kBFloat16,
-    }
-
-    return dtype_map.get(torch_dtype, torch_dtype)
-
-def _convert_dtype_params(func):
-    import functools
-    import inspect
-    import os
-
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        dtype_params = ['otype', 'output_dtype', 'bias_type']
-
-        from transformer_engine.plugin.core.ops import DType as PyDType
-
-        def needs_conversion(val):
-            return isinstance(val, torch.dtype) or isinstance(val, PyDType)
-
-        for param_name in dtype_params:
-            if param_name in kwargs:
-                value = kwargs[param_name]
-                if needs_conversion(value):
-                    converted = self._to_te_dtype(value)
-                    kwargs[param_name] = converted
-
-        sig = inspect.signature(func)
-        param_names = list(sig.parameters.keys())[1:]
-
-        args_list = list(args)
-        for i, (param_name, arg_value) in enumerate(zip(param_names, args_list)):
-            if param_name in dtype_params and needs_conversion(arg_value):
-                converted = self._to_te_dtype(arg_value)
-                args_list[i] = converted
-
-        return func(self, *args_list, **kwargs)
-
-    return wrapper
-
 class IluvatarBackend(TEFLBackendBase):
     @staticmethod
     def check_available() -> bool:
@@ -179,18 +117,42 @@ class IluvatarBackend(TEFLBackendBase):
             self._tex = _get_tex()
         return self._tex
 
-    def _to_te_dtype(self, torch_dtype):
-        return _torch_dtype_to_te_dtype(torch_dtype, self._get_tex())
-
     def is_available(self) -> bool:
         return _check_iluvatar_available()
-    
-    def get_flash_attention_class(self):
-        raise NotImplementedError("get_flash_attention_class - not implemented in iluvatar backend")
 
     def get_attention_backend(self, attention_params=None):
-        raise NotImplementedError("get_attention_backend - not implemented in iluvatar backend")
-    
+        from packaging.version import Version as PkgVersion
+        from ....logger_manager import get_logger
+        logger = get_logger()
+
+        # Read environment variables to determine which backends to enable
+        use_flash_attention = int(os.getenv("NVTE_FLASH_ATTN", "1"))
+        use_fused_attention = int(os.getenv("NVTE_FUSED_ATTN", "1"))
+        use_unfused_attention = int(os.getenv("NVTE_UNFUSED_ATTN", "1"))
+
+        # Log disabled backends
+        if not use_flash_attention:
+            logger.info_once("Disabling FlashAttention due to NVTE_FLASH_ATTN=0")
+        if not use_fused_attention:
+            logger.info_once("Disabling FusedAttention due to NVTE_FUSED_ATTN=0")
+        if not use_unfused_attention:
+            logger.info_once("Disabling UnfusedDotProductAttention due to NVTE_UNFUSED_ATTN=0")
+
+        flash_attention_backend = PkgVersion("2.6.0") if use_flash_attention else None
+        fused_attention_backend = NVTE_Fused_Attn_Backend.NVTE_No_Backend
+
+        available_backends = [use_flash_attention, use_fused_attention, use_unfused_attention]
+
+        return (
+            use_flash_attention,
+            flash_attention_backend,
+            use_fused_attention,
+            fused_attention_backend,
+            use_unfused_attention,
+            available_backends,
+        )
+
+##### transformer_engine/pytorch/csrc/extensions/pybind.cpp #####
     def quantize(
         self,
         tensor: torch.Tensor,
@@ -201,156 +163,134 @@ class IluvatarBackend(TEFLBackendBase):
         tex = self._get_tex()
         return tex.quantize(tensor, quantizer, output, noop)
 
-    @_convert_dtype_params
     def dequantize(
         self,
-        input: torch.Tensor,
-        otype: torch.dtype,
-    ) -> torch.Tensor:
+        input: Any,
+        otype: DType,
+    ) -> Any:
         tex = self._get_tex()
+        otype = tex.DType(int(otype)) if otype is not None else None
         return tex.dequantize(input, otype)
 
     def bgrad_quantize(
         self,
         input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
         return tex.bgrad_quantize(input, quantizer)
 
-    @_convert_dtype_params
     def generic_gemm(
         self,
-        A: torch.Tensor,
-        transA: bool,
-        B: torch.Tensor,
-        transB: bool,
-        D: torch.Tensor,
+        A: Any,
+        transa: bool,
+        B: Any,
+        transb: bool,
+        D: Any,
         quantizer: Any,
-        output_dtype: torch.dtype,
+        out_dtype: Optional[DType],
         bias: Optional[torch.Tensor],
-        bias_type: Any,
+        bias_type: DType,
         gelu: bool,
         gelu_in: Optional[torch.Tensor],
         grad: bool,
         workspace: torch.Tensor,
-        workspace_size: int,
+        workspaceSize: int,
         accumulate: bool,
         use_split_accumulator: bool,
         comm_overlap: Optional[Any] = None,
-        comm_type: Optional[Any] = None,
+        comm_type: Optional[CommOverlapType] = None,
         extra_output: Optional[torch.Tensor] = None,
         bulk_overlap: bool = False,
         alpha: float = 1.0,
         beta: Optional[float] = None,
-    ) -> Any:
-        # Check shape
+    ) -> List[Any]:
         tex = self._get_tex()
-
-        if bias_type is None:
-            bias_type = self._to_te_dtype(torch.bfloat16)
-
+        
+        bias_type = tex.DType(int(bias_type)) if bias_type is not None else None
+        comm_type = tex.CommOverlapType(int(comm_type)) if comm_type is not None else None
+        out_dtype = tex.DType(int(out_dtype)) if out_dtype is not None else None
         return tex.generic_gemm(
-            A, transA, B, transB, D, quantizer, output_dtype,
-            bias, bias_type, gelu, gelu_in, grad, workspace, workspace_size,
+            A, transa, B, transb, D, quantizer, out_dtype,
+            bias, bias_type, gelu, gelu_in, grad, workspace, workspaceSize,
             accumulate, use_split_accumulator, comm_overlap, comm_type,
             extra_output, bulk_overlap, alpha, beta
         )
-
-    def te_general_grouped_gemm(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.te_general_grouped_gemm(*args, **kwargs)
-
+    # GELU and variants #
     def gelu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.gelu(input, quantizer)
-
     def geglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.geglu(input, quantizer)
-
     def qgelu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.qgelu(input, quantizer)
-
     def qgeglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.qgeglu(input, quantizer)
-
+    # ReLU and variants #
     def relu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.relu(input, quantizer)
-
     def reglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.reglu(input, quantizer)
-
     def srelu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.srelu(input, quantizer)
-
     def sreglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.sreglu(input, quantizer)
-
+    # SwiGLU and variants #
     def silu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.silu(input, quantizer)
-
     def swiglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.swiglu(input, quantizer)
-
     def clamped_swiglu(
-            self,
-            input: torch.Tensor,
-            quantizer: Any,
-            limit: float = 7.0,
-            alpha: float = 1.702,
-        ) -> Any:
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+        limit: float = 7.0,
+        alpha: float = 1.702,
+    ) -> Any:
         tex = self._get_tex()
         return tex.clamped_swiglu(input, quantizer, limit, alpha)
-
+    # Backward of GELU and variants #
     def dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dgelu(grad, fwd_input, quantizer)
-
     def dgeglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dgeglu(grad, fwd_input, quantizer)
-
     def dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dqgelu(grad, fwd_input, quantizer)
-
     def dqgeglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dqgeglu(grad, fwd_input, quantizer)
-
+    # Backward of ReLU and variants #
     def drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.drelu(grad, fwd_input, quantizer)
-
     def dreglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dreglu(grad, fwd_input, quantizer)
-
     def dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dsrelu(grad, fwd_input, quantizer)
-
     def dsreglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dsreglu(grad, fwd_input, quantizer)
-
+    # Backward of SiLU and variants #
     def dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dsilu(grad, fwd_input, quantizer)
-
     def dswiglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dswiglu(grad, fwd_input, quantizer)
-
     def clamped_dswiglu(
         self,
         grad: torch.Tensor,
@@ -361,28 +301,137 @@ class IluvatarBackend(TEFLBackendBase):
     ) -> Any:
         tex = self._get_tex()
         return tex.clamped_dswiglu(grad, fwd_input, quantizer, limit, alpha)
-
+    # DBias + DAct fusions #
     def dbias_dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dgelu(grad, fwd_input, quantizer)
-
     def dbias_dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dsilu(grad, fwd_input, quantizer)
-
     def dbias_drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_drelu(grad, fwd_input, quantizer)
-
     def dbias_dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dqgelu(grad, fwd_input, quantizer)
-
     def dbias_dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dsrelu(grad, fwd_input, quantizer)
-
-    @_convert_dtype_params
+    # Permutation functions                                                                                                                                                                                                                                                                                             
+    def moe_permute_fwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        indices: torch.Tensor,
+        num_out_tokens: int,
+        workspace: List[torch.Tensor],
+        max_expanded_token_num: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, List[torch.Tensor]]:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_permute_fwd(input, dtype,indices,num_out_tokens,workspace,max_expanded_token_num)
+    def moe_permute_bwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+        num_tokens: int,
+        topK: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_permute_bwd(input,dtype,row_id_map,prob,num_tokens,topK)
+    def moe_unpermute_fwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+        num_tokens: int,
+        topK: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_unpermute_fwd(input,dtype,row_id_map,prob,num_tokens,topK)
+    def moe_unpermute_bwd(
+        self,
+        input_bwd: torch.Tensor,
+        input_fwd: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_unpermute_bwd(input_bwd,input_fwd,dtype,row_id_map,prob)
+    # Softmax functions
+    def scaled_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_softmax_forward(input, scale)
+    def scaled_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_softmax_backward(output_grad_, softmax_results_, scale_factor)
+    def scaled_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        mask: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_masked_softmax_forward(input, mask, scale_factor)
+    def scaled_masked_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_masked_softmax_backward(output_grad_, softmax_results_, scale_factor)
+    def scaled_upper_triang_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_upper_triang_masked_softmax_forward(input, scale_factor)
+    def scaled_upper_triang_masked_softmax_backward(
+        self,
+        output_grads_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_upper_triang_masked_softmax_backward(
+            output_grads_, softmax_results_, scale_factor
+        )
+    def scaled_aligned_causal_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_aligned_causal_masked_softmax_forward(input, scale_factor)
+    def scaled_aligned_causal_masked_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_aligned_causal_masked_softmax_backward(
+            output_grad_, softmax_results_, scale_factor
+        )
+    # Other granular functions
     def layernorm_fwd(
         self,
         input: torch.Tensor,
@@ -391,27 +440,18 @@ class IluvatarBackend(TEFLBackendBase):
         eps: float,
         ln_out: Optional[torch.Tensor],
         quantizer: Any,
-        otype: torch.dtype,
+        otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = input.shape
-        if input.ndim > 2:
-            input = input.view(-1, input.shape[-1])
-
-        y, mu, rsigma = tex.layernorm_fwd(
+        otype = tex.DType(int(otype)) if otype is not None else None
+        return tex.layernorm_fwd(
             input, weight, bias, eps, ln_out, quantizer, otype, sm_margin, zero_centered_gamma
         )
-
-        if len(orig_shape) > 2:
-            y = y.view(*orig_shape)
-        return y, mu, rsigma
-
     def layernorm_bwd(
         self,
-        dy: torch.Tensor,
+        dz: torch.Tensor,
         x: torch.Tensor,
         mu: torch.Tensor,
         rsigma: torch.Tensor,
@@ -420,19 +460,9 @@ class IluvatarBackend(TEFLBackendBase):
         zero_centered_gamma: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = dy.shape
-        if dy.ndim > 2:
-            dy = dy.view(-1, dy.shape[-1])
-            x = x.view(-1, x.shape[-1])
-
-        dx, dgamma, dbeta = tex.layernorm_bwd(dy, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma)
-
-        if len(orig_shape) > 2:
-            dx = dx.view(*orig_shape)
-        return dx, dgamma, dbeta
-
-    @_convert_dtype_params
+        return tex.layernorm_bwd(
+            dz, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma
+        )
     def rmsnorm_fwd(
         self,
         input: torch.Tensor,
@@ -440,52 +470,38 @@ class IluvatarBackend(TEFLBackendBase):
         eps: float,
         ln_out: Optional[torch.Tensor],
         quantizer: Any,
-        otype: torch.dtype,
+        otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = input.shape
-        if input.ndim > 2:
-            input = input.view(-1, input.shape[-1])
-
-        y, y_quant, rsigma = tex.rmsnorm_fwd(
+        otype = tex.DType(int(otype)) if otype is not None else None
+        return tex.rmsnorm_fwd(
             input, weight, eps, ln_out, quantizer, otype, sm_margin, zero_centered_gamma
         )
-
-        if len(orig_shape) > 2:
-            y = y.view(*orig_shape)
-            if y_quant is not None:
-                y_quant = y_quant.view(*orig_shape)
-        return y, y_quant, rsigma
-
     def rmsnorm_bwd(
         self,
-        dy: torch.Tensor,
+        dz: torch.Tensor,
         x: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
         sm_margin: int = 0,
         zero_centered_gamma: bool = False,
-        eps: float = 1e-5,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = dy.shape
-        if dy.ndim > 2:
-            dy = dy.view(-1, dy.shape[-1])
-            x = x.view(-1, x.shape[-1])
-
-        dx, dw = tex.rmsnorm_bwd(dy, x, rsigma, gamma, sm_margin, zero_centered_gamma)
-
-        if len(orig_shape) > 2:
-            dx = dx.view(*orig_shape)
-        return dx, dw
-
-    def rmsnorm_bwd_add(self, *args, **kwargs) -> Any:
+        return tex.rmsnorm_bwd(dz, x, rsigma, gamma, sm_margin, zero_centered_gamma)
+    def rmsnorm_bwd_add(
+        self,
+        dz: torch.Tensor,
+        x: torch.Tensor,
+        add: torch.Tensor,
+        rsigma: torch.Tensor,
+        gamma: torch.Tensor,
+        sm_margin: int = 0,
+        zero_centered_gamma: bool = False,
+    ) -> Any:
         tex = self._get_tex()
-        return tex.rmsnorm_bwd_add(*args, **kwargs)
+        return tex.rmsnorm_bwd_add(dz, x, add, rsigma, gamma, sm_margin, zero_centered_gamma)
 
     def multi_tensor_quantize(
         self,
@@ -494,7 +510,6 @@ class IluvatarBackend(TEFLBackendBase):
     ) -> List[Any]:
         tex = self._get_tex()
         return tex.multi_tensor_quantize(tensor_list, quantizer_list)
-
     def split_quantize(
         self,
         tensor: torch.Tensor,
@@ -503,357 +518,86 @@ class IluvatarBackend(TEFLBackendBase):
     ) -> List[Any]:
         tex = self._get_tex()
         return tex.split_quantize(tensor, split_sections, quantizer_list)
-
-    def moe_permute_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex._moe_permute_fwd(*args, **kwargs)
-    
-    def moe_permute_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex._moe_permute_bwd(*args, **kwargs)
-
-    def moe_unpermute_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex._moe_unpermute_fwd(*args, **kwargs)
-
-    def moe_unpermute_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex._moe_unpermute_bwd(*args, **kwargs)
-
-    def scaled_softmax_forward(self, input: torch.Tensor, scale: float) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_softmax_forward(input, scale)
-
-    def scaled_softmax_backward(
+    def te_general_grouped_gemm(
         self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
+        A: torch.Tensor,
+        transa: bool,
+        B: torch.Tensor,
+        transb: bool,
+        D: Optional[List[torch.Tensor]],
+        D_type: DType,
+        m_splits: List[int],
+        bias: List[torch.Tensor],
+        bias_type: DType,
+        single_output: bool,
+        pre_gelu_out: List[torch.Tensor],
+        grad: bool,
+        workspace: List[torch.Tensor],
+        workspaceSizes: int,
+        accumulate: bool,
+        use_split_accumulator: bool,
+        math_sm_count: int,
+    ) -> Optional[List[torch.Tensor]]:
         tex = self._get_tex()
-        return tex.scaled_softmax_backward(output_grad, softmax_output, scale)
-
-    def scaled_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        mask: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_masked_softmax_forward(input, mask, scale)
-
-    def scaled_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_masked_softmax_backward(output_grad, softmax_output, scale)
-
-    def scaled_upper_triang_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_upper_triang_masked_softmax_forward(input, scale)
-
-    def scaled_upper_triang_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_upper_triang_masked_softmax_backward(output_grad, softmax_output, scale)  
-
-    def scaled_aligned_causal_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_aligned_causal_masked_softmax_forward(input, scale)
-
-    def scaled_aligned_causal_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_aligned_causal_masked_softmax_backward(output_grad, softmax_output, scale)
-
-    def get_fused_attn_backend(self, *args, **kwargs) -> int:
-        tex = self._get_tex()
-
-        args_list = list(args)
-
-        def convert_enum(py_enum, native_enum_class):
-            if py_enum is None:
-                return None
-
-            if type(py_enum).__module__ == 'transformer_engine_torch_nv':
-                return py_enum
-
-            if hasattr(py_enum, 'name'):
-                enum_name = py_enum.name
-                if hasattr(native_enum_class, enum_name):
-                    return getattr(native_enum_class, enum_name)
-
-            if hasattr(py_enum, 'value'):
-                enum_value = int(py_enum.value)
-                for member_name in dir(native_enum_class):
-                    if not member_name.startswith('_'):
-                        try:
-                            member = getattr(native_enum_class, member_name)
-                            if hasattr(member, 'value') and int(member.value) == enum_value:
-                                return member
-                        except:
-                            pass
-
-            if hasattr(py_enum, 'value'):
-                return int(py_enum.value)
-
-            return py_enum
-
-        if len(args) > 1:
-            args_list[1] = self._to_te_dtype(args[1])
-        if len(args) > 2:
-            args_list[2] = self._to_te_dtype(args[2])
-        if len(args) > 3:
-            args_list[3] = convert_enum(args[3], tex.NVTE_QKV_Layout)
-        if len(args) > 4:
-            args_list[4] = convert_enum(args[4], tex.NVTE_Bias_Type)
-        if len(args) > 5:
-            args_list[5] = convert_enum(args[5], tex.NVTE_Mask_Type)
-        if len(args) > 6:
-            args_list[6] = convert_enum(args[6], tex.NVTE_Softmax_Type)
-
-        return tex.get_fused_attn_backend(*args_list, **kwargs)
-
-    def fused_attn_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-
-        def convert_enum(py_enum, native_enum_class):
-            if py_enum is None:
-                return None
-            if type(py_enum).__module__ == 'transformer_engine_torch_nv':
-                return py_enum
-            if hasattr(py_enum, 'name'):
-                enum_name = py_enum.name
-                if hasattr(native_enum_class, enum_name):
-                    return getattr(native_enum_class, enum_name)
-            return py_enum
-
-        args_list = list(args)
-        if len(args) > 6:
-            args_list[6] = convert_enum(args[6], tex.NVTE_QKV_Layout)
-        if len(args) > 7:
-            args_list[7] = convert_enum(args[7], tex.NVTE_Bias_Type)
-        if len(args) > 8:
-            args_list[8] = convert_enum(args[8], tex.NVTE_Mask_Type)
-        if len(args) > 9:
-            args_list[9] = convert_enum(args[9], tex.NVTE_Softmax_Type)
-
-        return tex.fused_attn_fwd(*args_list, **kwargs)
-
-    def fused_attn_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-
-        def convert_enum(py_enum, native_enum_class):
-            if py_enum is None:
-                return None
-            if type(py_enum).__module__ == 'transformer_engine_torch_nv':
-                return py_enum
-            if hasattr(py_enum, 'name'):
-                enum_name = py_enum.name
-                if hasattr(native_enum_class, enum_name):
-                    return getattr(native_enum_class, enum_name)
-            return py_enum
-
-        args_list = list(args)
-        if len(args) > 5:
-            args_list[5] = convert_enum(args[5], tex.NVTE_QKV_Layout)
-        if len(args) > 6:
-            args_list[6] = convert_enum(args[6], tex.NVTE_Bias_Type)
-        if len(args) > 7:
-            args_list[7] = convert_enum(args[7], tex.NVTE_Mask_Type)
-        if len(args) > 8:
-            args_list[8] = convert_enum(args[8], tex.NVTE_Softmax_Type)
-        if len(args) > 19:
-            args_list[19] = self._to_te_dtype(args[19])
-
-        if 'dqkv_dtype' in kwargs:
-            kwargs['dqkv_dtype'] = self._to_te_dtype(kwargs['dqkv_dtype'])
-
-        return tex.fused_attn_bwd(*args_list, **kwargs)
-
-    def fa_prepare_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fa_prepare_fwd(*args, **kwargs)
-
-    def fa_prepare_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fa_prepare_bwd(*args, **kwargs)
-
-    def copy_to_kv_cache(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.copy_to_kv_cache(*args, **kwargs)
-
-    def convert_thd_to_bshd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.convert_thd_to_bshd(*args, **kwargs)
-
-    def convert_bshd_to_thd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.convert_bshd_to_thd(*args, **kwargs)
-
-    def fused_rope_forward(self, *args, **kwargs) -> Any:
-        assert args[2] is None, "[Iluvatar] fused_rope_forward does not support start_position now."
-        assert args[3].name == "NVTE_SBHD", f"[Iluvatar] fused_rope_forward expect NVTE_SBHD, but got {args[3].name}."
-        tex = self._get_tex()
-        return tex.fused_rope_forward(args[0], args[1], False, False, 1.0)
-
-    def fused_rope_backward(self, *args, **kwargs) -> Any:
-        assert args[2].name == "NVTE_SBHD", f"[Iluvatar] fused_rope_backward expect NVTE_SBHD, but got {args[2].name}."
-        tex = self._get_tex()
-        return tex.fused_rope_backward(args[0], args[1], False, False, 1.0)
-
-    def fused_qkv_rope_forward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_qkv_rope_forward(*args, **kwargs)
-
-    def fused_qkv_rope_backward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_qkv_rope_backward(*args, **kwargs)
-
-    def fused_topk_with_score_function_fwd(
-        self,
-        logits: torch.Tensor,
-        topk: int,
-        use_pre_softmax: bool,
-        num_groups: int,
-        group_topk: int,
-        scaling_factor: float,
-        score_function: Any,
-        expert_bias: Optional[torch.Tensor],
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_topk_with_score_function_fwd(
-            logits, topk, use_pre_softmax, num_groups, group_topk,
-            scaling_factor, score_function, expert_bias
+        D_type = tex.DType(int(D_type)) if D_type is not None else None
+        bias_type = tex.DType(int(bias_type)) if bias_type is not None else None
+        return tex.te_general_grouped_gemm(
+            A, transa, B, transb, D, D_type, m_splits, bias, bias_type,
+            single_output, pre_gelu_out, grad, workspace, workspaceSizes,
+            accumulate, use_split_accumulator, math_sm_count
         )
-
-    def fused_topk_with_score_function_bwd(
-        self,
-        num_tokens: int,
-        num_experts: int,
-        routing_map: torch.Tensor,
-        intermediate_output: torch.Tensor,
-        grad_probs: torch.Tensor,
-        topk: int,
-        use_pre_softmax: bool,
-        scaling_factor: float,
-        score_function: Any,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_topk_with_score_function_bwd(
-            num_tokens, num_experts, routing_map, intermediate_output,
-            grad_probs, topk, use_pre_softmax, scaling_factor, score_function
-        )
-
-    def fused_score_for_moe_aux_loss_fwd(
-        self,
-        logits: torch.Tensor,
-        topk: int,
-        score_function: Any,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_score_for_moe_aux_loss_fwd(logits, topk, score_function)
-
-    def fused_score_for_moe_aux_loss_bwd(
-        self,
-        num_tokens: int,
-        num_experts: int,
-        intermediate_output: torch.Tensor,
-        grad_scores: torch.Tensor,
-        topk: int,
-        score_function: Any,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_score_for_moe_aux_loss_bwd(
-            num_tokens, num_experts, intermediate_output, grad_scores, topk, score_function
-        )
-
-    def fused_moe_aux_loss_fwd(
-        self,
-        probs: torch.Tensor,
-        tokens_per_expert: torch.Tensor,
-        total_num_tokens: int,
-        num_experts: int,
-        num_rows: int,
-        num_cols: int,
-        topk: int,
-        coeff: float,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_moe_aux_loss_fwd(
-            probs, tokens_per_expert, total_num_tokens, num_experts,
-            num_rows, num_cols, topk, coeff
-        )
-
-    def fused_moe_aux_loss_bwd(
-        self,
-        Const_buf: torch.Tensor,
-        tokens_per_expert: torch.Tensor,
-        num_rows: int,
-        num_cols: int,
-        grad_aux_loss: torch.Tensor,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_moe_aux_loss_bwd(
-            Const_buf, tokens_per_expert, num_rows, num_cols, grad_aux_loss
-        )
-
-    def dropout_fwd(
-        self,
-        input: torch.Tensor,
-        dropout_probability: float,
-        out: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        tex = self._get_tex()
-        return tex.dropout_fwd(input, dropout_probability, out)
-
-    def dropout_bwd(
-        self,
-        grad_output: torch.Tensor,
-        mask: torch.Tensor,
-        dropout_probability: float,
-        grad_input: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.dropout_bwd(grad_output, mask, dropout_probability, grad_input)
-
     def fp8_transpose(
         self,
         input: torch.Tensor,
-        dtype: Any,
-        *,
-        out: torch.Tensor,
-    ) -> None:
+        otype: DType,
+        output: Optional[torch.Tensor],
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        tex.fp8_transpose(input, dtype, out=out)
-
+        otype = tex.DType(int(otype)) if otype is not None else None
+        return tex.fp8_transpose(input, otype, output)
     def swap_first_dims(
         self,
         tensor: torch.Tensor,
-        *,
-        out: torch.Tensor,
-    ) -> None:
+        out: Optional[torch.Tensor],
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        tex.swap_first_dims(tensor, out=out)
+        return tex.swap_first_dims(tensor, out)
+    def get_fused_attn_backend(
+        self,
+        is_training: bool,
+        q_dtype: DType,
+        kv_dtype: DType,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        p_dropout: float,
+        num_attn_heads: int,
+        num_gqa_groups: int,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        head_dim_qk: int,
+        head_dim_v: int,
+        window_size_left: int,
+        window_size_right: int,
+        return_max_logit: bool,
+    ) -> NVTE_Fused_Attn_Backend:
+        tex = self._get_tex()
+
+        q_dtype = tex.DType(int(q_dtype)) if q_dtype is not None else None
+        kv_dtype = tex.DType(int(kv_dtype)) if kv_dtype is not None else None
+        qkv_layout = tex.NVTE_QKV_Layout(int(qkv_layout)) if qkv_layout is not None else None
+        bias_type = tex.NVTE_Bias_Type(int(bias_type)) if bias_type is not None else None
+        attn_mask_type = tex.NVTE_Mask_Type(int(attn_mask_type)) if attn_mask_type is not None else None
+        softmax_type = tex.NVTE_Softmax_Type(int(softmax_type)) if softmax_type is not None else None
+
+        result = tex.get_fused_attn_backend(
+            is_training, q_dtype, kv_dtype, qkv_layout, bias_type,
+            attn_mask_type, softmax_type, p_dropout, num_attn_heads,
+            num_gqa_groups, max_seqlen_q, max_seqlen_kv, head_dim_qk,
+            head_dim_v, window_size_left, window_size_right, return_max_logit
+        )
+        return NVTE_Fused_Attn_Backend(result)
 
     def compute_amax(
         self,
@@ -861,12 +605,22 @@ class IluvatarBackend(TEFLBackendBase):
         amax: torch.Tensor,
     ) -> None:
         tex = self._get_tex()
-        tex.compute_amax(input, amax)
-
-    def fused_amax_and_scale_update_after_reduction(self, *args, **kwargs) -> None:
+        return tex.compute_amax(input, amax)
+    def fused_amax_and_scale_update_after_reduction(
+        self,
+        amax_reduction_buffer: torch.Tensor,
+        amax_histories: List[torch.Tensor],
+        scales: List[torch.Tensor],
+        amax_compute_algo: str,
+        fp8_dtype: DType,
+        margin: float,
+    ) -> None:
         tex = self._get_tex()
-        tex.fused_amax_and_scale_update_after_reduction(*args, **kwargs)
-
+        fp8_dtype = tex.DType(int(fp8_dtype)) if fp8_dtype is not None else None
+        return tex.fused_amax_and_scale_update_after_reduction(
+            amax_reduction_buffer, amax_histories, scales,
+            amax_compute_algo, fp8_dtype, margin
+        )
     def fp8_block_scaling_compute_partial_amax(
         self,
         tensor: torch.Tensor,
@@ -877,8 +631,9 @@ class IluvatarBackend(TEFLBackendBase):
         block_len: int,
     ) -> None:
         tex = self._get_tex()
-        tex.fp8_block_scaling_compute_partial_amax(tensor, amax, h, w, start_offset, block_len)
-
+        return tex.fp8_block_scaling_compute_partial_amax(
+            tensor, amax, h, w, start_offset, block_len
+        )
     def fp8_block_scaling_partial_cast(
         self,
         inp: torch.Tensor,
@@ -888,75 +643,555 @@ class IluvatarBackend(TEFLBackendBase):
         w: int,
         start_offset: int,
         block_len: int,
-        out_dtype: Any,
+        out_dtype: DType,
     ) -> None:
         tex = self._get_tex()
-        tex.fp8_block_scaling_partial_cast(inp, out, scale, h, w, start_offset, block_len, out_dtype)
-
-    def fused_multi_row_padding(self, *args, **kwargs) -> Any:
+        out_dtype = tex.DType(int(out_dtype)) if out_dtype is not None else None
+        return tex.fp8_block_scaling_partial_cast(
+            inp, out, scale, h, w, start_offset, block_len, out_dtype
+        )
+    def fused_multi_row_padding(
+        self,
+        input: torch.Tensor,
+        output: torch.Tensor,
+        input_row_list: List[int],
+        padded_input_row_list: List[int],
+    ) -> None:
         tex = self._get_tex()
-        return tex.fused_multi_row_padding(*args, **kwargs)
-
-    def fused_multi_row_unpadding(self, *args, **kwargs) -> Any:
+        return tex.fused_multi_row_padding(
+            input, output, input_row_list, padded_input_row_list
+        )
+    def fused_multi_row_unpadding(
+        self,
+        input: torch.Tensor,
+        output: torch.Tensor,
+        input_row_list: List[int],
+        unpadded_input_row_list: List[int],
+    ) -> None:
         tex = self._get_tex()
-        return tex.fused_multi_row_unpadding(*args, **kwargs)
+        return tex.fused_multi_row_unpadding(
+            input, output, input_row_list, unpadded_input_row_list
+        )
 
+    # attention kernels
+    def fa_prepare_fwd(
+        self,
+        qkvi: torch.Tensor,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fa_prepare_fwd(qkvi)
+    def fa_prepare_bwd(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fa_prepare_bwd(q, k, v)
+    def fused_attn_fwd(
+        self,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        is_training: bool,
+        attn_scale: float,
+        p_dropout: float,
+        set_zero: bool,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        window_size: List[int],
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_kv: torch.Tensor,
+        Q: Any,
+        K: Any,
+        V: Any,
+        fake_dtype: torch.dtype,
+        cu_seqlens_q_padded: Optional[torch.Tensor],
+        cu_seqlens_kv_padded: Optional[torch.Tensor],
+        page_table_k: Optional[torch.Tensor],
+        page_table_v: Optional[torch.Tensor],
+        s_quantizer: Any,
+        o_quantizer: Any,
+        Bias: Optional[torch.Tensor],
+        SoftmaxOffset: Optional[torch.Tensor],
+        rng_gen: Optional[torch.Generator],
+        rng_elts_per_thread: int,
+        return_max_logit: bool,
+    ) -> List[Any]:
+        tex = self._get_tex()
+
+        qkv_layout = tex.NVTE_QKV_Layout(int(qkv_layout)) if qkv_layout is not None else None
+        bias_type = tex.NVTE_Bias_Type(int(bias_type)) if bias_type is not None else None
+        attn_mask_type = tex.NVTE_Mask_Type(int(attn_mask_type)) if attn_mask_type is not None else None
+        softmax_type = tex.NVTE_Softmax_Type(int(softmax_type)) if softmax_type is not None else None
+
+        return tex.fused_attn_fwd(
+            max_seqlen_q,
+            max_seqlen_kv,
+            is_training,
+            attn_scale,
+            p_dropout,
+            set_zero,
+            qkv_layout,
+            bias_type,
+            attn_mask_type,
+            softmax_type,
+            window_size,
+            cu_seqlens_q,
+            cu_seqlens_kv,
+            Q,
+            K,
+            V,
+            fake_dtype,
+            cu_seqlens_q_padded,
+            cu_seqlens_kv_padded,
+            page_table_k,
+            page_table_v,
+            s_quantizer,
+            o_quantizer,
+            Bias,
+            SoftmaxOffset,
+            rng_gen,
+            rng_elts_per_thread,
+            return_max_logit
+        )
+    def fused_attn_bwd(
+        self,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        attn_scale: float,
+        p_dropout: float,
+        set_zero: bool,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        window_size: List[int],
+        deterministic: bool,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_kv: torch.Tensor,
+        Q: Any,
+        K: Any,
+        V: Any,
+        O: Any,
+        dO: Any,
+        fake_dtype: torch.dtype,
+        dqkv_type: DType,
+        Aux_CTX_Tensors: List[torch.Tensor],
+        cu_seqlens_q_padded: Optional[torch.Tensor],
+        cu_seqlens_kv_padded: Optional[torch.Tensor],
+        s_quantizer: Any,
+        dp_quantizer: Any,
+        dqkv_quantizer: Any,
+    ) -> List[Any]:
+        tex = self._get_tex()
+
+        qkv_layout = tex.NVTE_QKV_Layout(int(qkv_layout)) if qkv_layout is not None else None
+        bias_type = tex.NVTE_Bias_Type(int(bias_type)) if bias_type is not None else None
+        attn_mask_type = tex.NVTE_Mask_Type(int(attn_mask_type)) if attn_mask_type is not None else None
+        softmax_type = tex.NVTE_Softmax_Type(int(softmax_type)) if softmax_type is not None else None
+        dqkv_type = tex.DType(int(dqkv_type)) if dqkv_type is not None else None
+
+        return tex.fused_attn_bwd(
+            max_seqlen_q,
+            max_seqlen_kv,
+            attn_scale,
+            p_dropout,
+            set_zero,
+            qkv_layout,
+            bias_type,
+            attn_mask_type,
+            softmax_type,
+            window_size,
+            deterministic,
+            cu_seqlens_q,
+            cu_seqlens_kv,
+            Q,
+            K,
+            V,
+            O,
+            dO,
+            fake_dtype,
+            dqkv_type,
+            Aux_CTX_Tensors,
+            cu_seqlens_q_padded,
+            cu_seqlens_kv_padded,
+            s_quantizer,
+            dp_quantizer,
+            dqkv_quantizer
+        )
+    def copy_to_kv_cache(
+        self,
+        new_k: torch.Tensor,
+        new_v: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        page_table: torch.Tensor,
+        cu_new_lens: torch.Tensor,
+        cu_cached_lens: torch.Tensor,
+        qkv_format: NVTE_QKV_Format,
+        b: int,
+        max_ctx_len: int,
+        max_seq_len: int,
+        max_pages_per_seq: int,
+        is_non_paged: bool,
+    ) -> None:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.copy_to_kv_cache(
+            new_k,
+            new_v,
+            k_cache,
+            v_cache,
+            page_table,
+            cu_new_lens,
+            cu_cached_lens,
+            qkv_format,
+            b,
+            max_ctx_len,
+            max_seq_len,
+            max_pages_per_seq,
+            is_non_paged
+        )
+    def convert_thd_to_bshd(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        b: int,
+        max_seq_len: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.convert_thd_to_bshd(tensor, cu_seqlens, b, max_seq_len)
+    def convert_bshd_to_thd(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        t: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.convert_bshd_to_thd(tensor, cu_seqlens, t)
+
+    # fused apply rope
+    def fused_rope_forward(
+        self,
+        input: torch.Tensor,
+        freqs: torch.Tensor,
+        start_positions: Optional[torch.Tensor],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cu_seqlens: Optional[torch.Tensor],
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_rope_forward(
+            input, freqs, start_positions, qkv_format,
+            interleaved, cu_seqlens, cp_size, cp_rank
+        )
+    def fused_rope_backward(
+        self,
+        output_grads: torch.Tensor,
+        freqs: torch.Tensor,
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cu_seqlens: Optional[torch.Tensor],
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_rope_backward(
+            output_grads, freqs, qkv_format,
+            interleaved, cu_seqlens, cp_size, cp_rank
+        )
+    def fused_qkv_rope_forward(
+        self,
+        qkv_input: torch.Tensor,
+        q_freqs: torch.Tensor,
+        k_freqs: torch.Tensor,
+        start_positions: Optional[torch.Tensor],
+        qkv_split_arg_list: List[int],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cp_size: int,
+        cp_rank: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_qkv_rope_forward(
+            qkv_input, q_freqs, k_freqs, start_positions,
+            qkv_split_arg_list, qkv_format, interleaved,
+            cp_size, cp_rank
+        )
+    def fused_qkv_rope_backward(
+        self,
+        q_grad_out: torch.Tensor,
+        k_grad_out: torch.Tensor,
+        v_grad_out: torch.Tensor,
+        q_freqs: torch.Tensor,
+        k_freqs: torch.Tensor,
+        qkv_split_arg_list: List[int],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_qkv_rope_backward(
+            q_grad_out, k_grad_out, v_grad_out,
+            q_freqs, k_freqs, qkv_split_arg_list,
+            qkv_format, interleaved, cp_size, cp_rank
+        )
+
+    # fused router
+    def fused_topk_with_score_function_fwd(
+        self,
+        logits: torch.Tensor,
+        topk: int,
+        use_pre_softmax: bool,
+        num_groups: Optional[int],
+        group_topk: Optional[int],
+        scaling_factor: Optional[float],
+        score_function: str,
+        expert_bias: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.fused_topk_with_score_function_fwd(
+            logits,
+            topk,
+            use_pre_softmax,
+            num_groups,
+            group_topk,
+            scaling_factor,
+            score_function,
+            expert_bias,
+        )
+    def fused_topk_with_score_function_bwd(
+        self,
+        num_tokens: int,
+        num_experts: int,
+        routing_map: torch.Tensor,
+        intermediate_output: torch.Tensor,
+        grad_probs: torch.Tensor,
+        topk: int,
+        use_pre_softmax: bool,
+        scaling_factor: Optional[float],
+        score_function: str,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fused_topk_with_score_function_bwd(
+            num_tokens,
+            num_experts,
+            routing_map,
+            intermediate_output,
+            grad_probs,
+            topk,
+            use_pre_softmax,
+            scaling_factor,
+            score_function,
+        )
+    def fused_score_for_moe_aux_loss_fwd(
+        self,
+        logits: torch.Tensor,
+        topk: int,
+        score_function: str,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.fused_score_for_moe_aux_loss_fwd(
+            logits,
+            topk,
+            score_function,
+        )
+    def fused_score_for_moe_aux_loss_bwd(
+        self,
+        num_tokens: int,
+        num_experts: int,
+        intermediate_output: torch.Tensor,
+        grad_scores: torch.Tensor,
+        topk: int,
+        score_function: str,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fused_score_for_moe_aux_loss_bwd(
+            num_tokens,
+            num_experts,
+            intermediate_output,
+            grad_scores,
+            topk,
+            score_function,
+        )
+    def fused_moe_aux_loss_fwd(
+        self,
+        probs: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        total_num_tokens: int,
+        num_experts: int,
+        num_rows: int,
+        num_cols: int,
+        topk: int,
+        coeff: float,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.fused_moe_aux_loss_fwd(
+            probs,
+            tokens_per_expert,
+            total_num_tokens,
+            num_experts,
+            num_rows,
+            num_cols,
+            topk,
+            coeff,
+        )
+    def fused_moe_aux_loss_bwd(
+        self,
+        Const_buf: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        num_rows: int,
+        num_cols: int,
+        grad_aux_loss: torch.Tensor,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fused_moe_aux_loss_bwd(Const_buf, tokens_per_expert, num_rows, num_cols, grad_aux_loss)
+
+    # Dropout
+    def dropout_fwd(
+        self,
+        input: torch.Tensor,
+        dropout_probability: float,
+        out: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.dropout_fwd(input, dropout_probability, out)
+    def dropout_bwd(
+        self,
+        grad_output: torch.Tensor,
+        mask: torch.Tensor,
+        dropout_probability: float,
+        grad_input: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.dropout_bwd(grad_output, mask, dropout_probability, grad_input)
+
+    # Misc
     def get_cublasLt_version(self) -> int:
         tex = self._get_tex()
         return tex.get_cublasLt_version()
-
     def get_cudnn_version(self) -> int:
         tex = self._get_tex()
         return tex.get_cudnn_version()
-
     def get_num_cublas_streams(self) -> int:
         tex = self._get_tex()
         return tex.get_num_cublas_streams()
 
-    def thd_read_half_tensor(self, *args, **kwargs) -> Any:
+    # Support THD format for Context Parallel
+    def thd_read_half_tensor(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        half_idx: int,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.thd_read_half_tensor(*args, **kwargs)
-
-    def thd_second_half_lse_correction(self, *args, **kwargs) -> Any:
+        return tex.thd_read_half_tensor(tensor, cu_seqlens, half_idx)
+    def thd_second_half_lse_correction(
+        self,
+        lse: torch.Tensor,
+        lse_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        lse_packed: bool,
+    ) -> None:
         tex = self._get_tex()
-        return tex.thd_second_half_lse_correction(*args, **kwargs)
-
-    def thd_read_second_half_lse(self, *args, **kwargs) -> Any:
+        return tex.thd_second_half_lse_correction(
+            lse, lse_per_step, cu_seqlens, lse_packed
+        )
+    def thd_read_second_half_lse(
+        self,
+        lse: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        lse_packed: bool,
+        second_half_lse_seqlen: int,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.thd_read_second_half_lse(*args, **kwargs)
-
-    def thd_out_correction(self, *args, **kwargs) -> Any:
+        return tex.thd_read_second_half_lse(
+            lse, cu_seqlens, lse_packed, second_half_lse_seqlen
+        )
+    def thd_out_correction(
+        self,
+        out: torch.Tensor,
+        out_per_step: torch.Tensor,
+        lse: torch.Tensor,
+        lse_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        only_second_half: bool,
+        lse_packed: bool,
+    ) -> None:
         tex = self._get_tex()
-        return tex.thd_out_correction(*args, **kwargs)
-
-    def thd_grad_correction(self, *args, **kwargs) -> Any:
+        return tex.thd_out_correction(
+            out, out_per_step, lse, lse_per_step,
+            cu_seqlens, only_second_half, lse_packed
+        )
+    def thd_grad_correction(
+        self,
+        grad: torch.Tensor,
+        grad_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        first_half: str,
+        second_half: str,
+    ) -> None:
         tex = self._get_tex()
-        return tex.thd_grad_correction(*args, **kwargs)
-
-    def thd_get_partitioned_indices(self, *args, **kwargs) -> Any:
+        return tex.thd_grad_correction(
+            grad, grad_per_step, cu_seqlens,
+            first_half, second_half
+        )
+    def thd_get_partitioned_indices(
+        self,
+        cu_seqlens: torch.Tensor,
+        total_tokens: int,
+        world_size: int,
+        rank: int,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.thd_get_partitioned_indices(*args, **kwargs)
+        return tex.thd_get_partitioned_indices(
+            cu_seqlens, total_tokens, world_size, rank
+        )
 
-    def init_nvshmem_backend(self, *args, **kwargs) -> None:
+    # nvshmem functions
+    def init_nvshmem_backend(
+        self,
+        process_group: Any,
+    ) -> None:
         tex = self._get_tex()
-        tex.init_nvshmem_backend(*args, **kwargs)
-
-    def create_nvshmem_tensor(self, *args, **kwargs) -> torch.Tensor:
+        return tex.init_nvshmem_backend(process_group)
+    def create_nvshmem_tensor(
+        self,
+        shape: List[int],
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.create_nvshmem_tensor(*args, **kwargs)
-
-    def nvshmem_send_on_current_stream(self, *args, **kwargs) -> None:
+        return tex.create_nvshmem_tensor(shape, dtype)
+    def nvshmem_send_on_current_stream(
+        self,
+        src: torch.Tensor,
+        dst: torch.Tensor,
+        peer: int,
+        signal: torch.Tensor,
+    ) -> None:
         tex = self._get_tex()
-        tex.nvshmem_send_on_current_stream(*args, **kwargs)
-
-    def nvshmem_wait_on_current_stream(self, *args, **kwargs) -> None:
+        return tex.nvshmem_send_on_current_stream(src, dst, peer, signal)
+    def nvshmem_wait_on_current_stream(
+        self,
+        signal: torch.Tensor,
+        wait_kind: str,
+    ) -> None:
         tex = self._get_tex()
-        tex.nvshmem_wait_on_current_stream(*args, **kwargs)
-
+        return tex.nvshmem_wait_on_current_stream(signal, wait_kind)
     def nvshmem_finalize(self) -> None:
         tex = self._get_tex()
-        tex.nvshmem_finalize()
+        return tex.nvshmem_finalize()
 
+    # multi-tensor functions
     def multi_tensor_scale(
         self,
         chunk_size: int,
@@ -965,98 +1200,194 @@ class IluvatarBackend(TEFLBackendBase):
         scale: float,
     ) -> None:
         tex = self._get_tex()
-        tex.multi_tensor_scale(chunk_size, noop_flag, tensor_lists, scale)
-
+        return tex.multi_tensor_scale(chunk_size, noop_flag, tensor_lists, scale)
     def multi_tensor_l2norm(
         self,
         chunk_size: int,
         noop_flag: torch.Tensor,
         tensor_lists: List[List[torch.Tensor]],
-        per_tensor: bool = False,
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
+        per_tensor: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
         return tex.multi_tensor_l2norm(chunk_size, noop_flag, tensor_lists, per_tensor)
-
     def multi_tensor_unscale_l2norm(
         self,
         chunk_size: int,
         noop_flag: torch.Tensor,
         tensor_lists: List[List[torch.Tensor]],
-        scale: torch.Tensor,
-        per_tensor: bool = False,
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
+        inv_scale: torch.Tensor,
+        per_tensor: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-        return tex.multi_tensor_unscale_l2norm(chunk_size, noop_flag, tensor_lists, scale, per_tensor)
-
+        return tex.multi_tensor_unscale_l2norm(
+            chunk_size, noop_flag, tensor_lists, inv_scale, per_tensor
+        )
     def multi_tensor_adam(
         self,
-        chunk_size: int = None,
-        noop_flag: torch.Tensor = None,
-        tensor_lists: List[List[torch.Tensor]] = None,
-        lr: float = None,
-        beta1: float = None,
-        beta2: float = None,
-        eps: float = None,
-        step: int = None,
-        mode: int = None,
-        bias_correction: int = None,
-        weight_decay: float = None,
-    ):
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
         tex = self._get_tex()
-        if chunk_size is None:
-            return tex.multi_tensor_adam
-        tex.multi_tensor_adam(
-            chunk_size, noop_flag, tensor_lists, lr, beta1, beta2,
-            eps, step, mode, bias_correction, weight_decay
+        return tex.multi_tensor_adam(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay
+        )
+    def multi_tensor_adam_param_remainder(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_adam_param_remainder(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay
+        )
+    def multi_tensor_adam_fp8(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        fp8_dtype: DType,
+    ) -> None:
+        tex = self._get_tex()
+        fp8_dtype = tex.DType(int(fp8_dtype)) if fp8_dtype is not None else None
+        return tex.multi_tensor_adam_fp8(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
+            fp8_dtype
+        )
+    def multi_tensor_adam_capturable(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: torch.Tensor,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: torch.Tensor,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        inv_scale: torch.Tensor,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_adam_capturable(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
+            inv_scale
+        )
+    def multi_tensor_adam_capturable_master(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: torch.Tensor,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: torch.Tensor,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        inv_scale: torch.Tensor,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_adam_capturable_master(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
+            inv_scale
+        )
+    def multi_tensor_sgd(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        wd: float,
+        momentum: float,
+        dampening: float,
+        lr: float,
+        nesterov: bool,
+        first_run: bool,
+        wd_after_momentum: bool,
+        scale: float,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_sgd(
+            chunk_size, noop_flag, tensor_lists,
+            wd, momentum, dampening,
+            lr, nesterov, first_run,
+            wd_after_momentum, scale
+        )
+    def multi_tensor_compute_scale_and_scale_inv(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        max_fp8: float,
+        force_pow_2_scales: bool,
+        epsilon: float,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_compute_scale_and_scale_inv(
+            chunk_size, noop_flag, tensor_lists,
+            max_fp8, force_pow_2_scales, epsilon
         )
 
-    def multi_tensor_adam_param_remainder(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_param_remainder(*args, **kwargs)
-
-    def multi_tensor_adam_fp8(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_fp8(*args, **kwargs)
-
-    def multi_tensor_adam_capturable(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_capturable(*args, **kwargs)
-
-    def multi_tensor_adam_capturable_master(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_capturable_master(*args, **kwargs)
-
-    def multi_tensor_sgd(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_sgd(*args, **kwargs)
-
-    def multi_tensor_compute_scale_and_scale_inv(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_compute_scale_and_scale_inv(*args, **kwargs)
-
+    # Comm+GEMM Overlap
     def bulk_overlap_ag_with_external_gemm(
         self,
-        allgather_communicator: Any,
+        allgather_communicator: CommOverlap,
         send_stream: Any,
         recv_stream: Any,
     ) -> Any:
         tex = self._get_tex()
         return tex.bulk_overlap_ag_with_external_gemm(allgather_communicator, send_stream, recv_stream)
 
+############## class func #################################
+    def get_flash_attention_class(self):
+        raise NotImplementedError("get_flash_attention_class - not implemented in iluvatar backend")
     def create_fp8_tensor_meta(self) -> FP8TensorMeta:
         tex = self._get_tex()
         return tex.FP8TensorMeta()
-
     def create_comm_overlap_helper(
         self,
         world_group: Optional[Any] = None,
         intra_node_group: Optional[Any] = None,
-    ) -> Any:
+    ) -> "CommOverlapHelper":
         tex = self._get_tex()
-        if world_group is None:
-            return tex.CommOverlapHelper()
         return tex.CommOverlapHelper(world_group, intra_node_group)
-
     def create_comm_overlap(
         self,
         buffer_shape: List[int],
@@ -1072,7 +1403,7 @@ class IluvatarBackend(TEFLBackendBase):
         set_sm_margin: bool = True,
         atomic_gemm: bool = False,
         rs_overlap_first_gemm: bool = False,
-    ) -> Any:
+    ) -> "CommOverlap":
         tex = self._get_tex()
         return tex.CommOverlap(
             buffer_shape, buffer_dtype, helper, tp_size,
@@ -1080,7 +1411,6 @@ class IluvatarBackend(TEFLBackendBase):
             gemm_priority, comm_priority, num_comm_sm,
             set_sm_margin, atomic_gemm, rs_overlap_first_gemm
         )
-
     def create_comm_overlap_p2p(
         self,
         buffer_shape: List[int],
@@ -1097,13 +1427,10 @@ class IluvatarBackend(TEFLBackendBase):
         atomic_gemm: bool = False,
         use_ce: bool = True,
         aggregate: bool = False,
-    ) -> Any:
+    ) -> "CommOverlapP2P":
         tex = self._get_tex()
         return tex.CommOverlapP2P(
             buffer_shape, buffer_dtype, helper, tp_size, comm_type,
             num_max_streams, comm_cga_size, gemm_priority, comm_priority,
             num_comm_sm, set_sm_margin, atomic_gemm, use_ce, aggregate
         )
-
-    
-    

--- a/transformer_engine/plugin/core/backends/vendor/kunlunxin/kunlunxin.py
+++ b/transformer_engine/plugin/core/backends/vendor/kunlunxin/kunlunxin.py
@@ -5,10 +5,8 @@
 import os
 import subprocess
 from typing import Any, Dict, List, Optional, Tuple, Union
-
 import torch
-
-from transformer_engine.plugin.core.ops import TEFLBackendBase, FP8TensorMeta, NVTE_Fused_Attn_Backend
+from ....ops import *
 
 _kunlunxin_available = False
 

--- a/transformer_engine/plugin/core/backends/vendor/metax/metax.py
+++ b/transformer_engine/plugin/core/backends/vendor/metax/metax.py
@@ -131,26 +131,26 @@ class MetaxBackend(TEFLBackendBase):
         self,
         input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.bgrad_quantize(input, quantizer)
 
     def generic_gemm(
         self,
         A: Any,
-        transa: bool,
+        transA: bool,
         B: Any,
-        transb: bool,
+        transB: bool,
         D: Any,
         quantizer: Any,
-        out_dtype: Optional[DType],
+        output_dtype: Optional[DType],
         bias: Optional[torch.Tensor],
         bias_type: DType,
         gelu: bool,
         gelu_in: Optional[torch.Tensor],
         grad: bool,
         workspace: torch.Tensor,
-        workspaceSize: int,
+        workspace_size: int,
         accumulate: bool,
         use_split_accumulator: bool,
         comm_overlap: Optional[Any] = None,
@@ -164,10 +164,10 @@ class MetaxBackend(TEFLBackendBase):
         
         bias_type = tex.DType(int(bias_type)) if bias_type is not None else None
         comm_type = tex.CommOverlapType(int(comm_type)) if comm_type is not None else None
-        out_dtype = tex.DType(int(out_dtype)) if out_dtype is not None else None
+        output_dtype = tex.DType(int(output_dtype)) if output_dtype is not None else None
         return tex.generic_gemm(
-            A, transa, B, transb, D, quantizer, out_dtype,
-            bias, bias_type, gelu, gelu_in, grad, workspace, workspaceSize,
+            A, transA, B, transB, D, quantizer, output_dtype,
+            bias, bias_type, gelu, gelu_in, grad, workspace, workspace_size,
             accumulate, use_split_accumulator, comm_overlap, comm_type,
             extra_output, bulk_overlap, alpha, beta
         )
@@ -257,19 +257,19 @@ class MetaxBackend(TEFLBackendBase):
         tex = self._get_tex()
         return tex.clamped_dswiglu(grad, fwd_input, quantizer, limit, alpha)
     # DBias + DAct fusions #
-    def dbias_dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dgelu(grad, fwd_input, quantizer)
-    def dbias_dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dsilu(grad, fwd_input, quantizer)
-    def dbias_drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_drelu(grad, fwd_input, quantizer)
-    def dbias_dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dqgelu(grad, fwd_input, quantizer)
-    def dbias_dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
+    def dbias_dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> List[Any]:
         tex = self._get_tex()
         return tex.dbias_dsrelu(grad, fwd_input, quantizer)
     # Permutation functions                                                                                                                                                                                                                                                                                             
@@ -393,12 +393,12 @@ class MetaxBackend(TEFLBackendBase):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor],
         eps: float,
-        ln_out: Optional[torch.Tensor],
+        ln_out: Any,
         quantizer: Any,
         otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> List[Any]:
         tex = self._get_tex()
         otype = tex.DType(int(otype)) if otype is not None else None
         return tex.layernorm_fwd(
@@ -411,24 +411,24 @@ class MetaxBackend(TEFLBackendBase):
         mu: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.layernorm_bwd(
             dz, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma
         )
     def rmsnorm_fwd(
         self,
-        input: torch.Tensor,
-        weight: torch.Tensor,
+        input: Any,
+        weight: Any,
         eps: float,
-        ln_out: Optional[torch.Tensor],
+        ln_out: Any,
         quantizer: Any,
         otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    ) -> List[Any]:
         tex = self._get_tex()
         otype = tex.DType(int(otype)) if otype is not None else None
         return tex.rmsnorm_fwd(
@@ -440,9 +440,9 @@ class MetaxBackend(TEFLBackendBase):
         x: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.rmsnorm_bwd(dz, x, rsigma, gamma, sm_margin, zero_centered_gamma)
     def rmsnorm_bwd_add(
@@ -452,9 +452,9 @@ class MetaxBackend(TEFLBackendBase):
         add: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Any:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         tex = self._get_tex()
         return tex.rmsnorm_bwd_add(dz, x, add, rsigma, gamma, sm_margin, zero_centered_gamma)
 
@@ -475,9 +475,9 @@ class MetaxBackend(TEFLBackendBase):
         return tex.split_quantize(tensor, split_sections, quantizer_list)
     def te_general_grouped_gemm(
         self,
-        A: torch.Tensor,
+        A: List[Any],
         transa: bool,
-        B: torch.Tensor,
+        B: List[Any],
         transb: bool,
         D: Optional[List[torch.Tensor]],
         D_type: DType,
@@ -504,12 +504,12 @@ class MetaxBackend(TEFLBackendBase):
     def fp8_transpose(
         self,
         input: torch.Tensor,
-        otype: DType,
-        output: Optional[torch.Tensor],
+        dtype: DType,
+        out: Optional[torch.Tensor],
     ) -> torch.Tensor:
         tex = self._get_tex()
-        otype = tex.DType(int(otype)) if otype is not None else None
-        return tex.fp8_transpose(input, otype, output)
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.fp8_transpose(input, dtype, out)
     def swap_first_dims(
         self,
         tensor: torch.Tensor,

--- a/transformer_engine/plugin/core/backends/vendor/metax/metax.py
+++ b/transformer_engine/plugin/core/backends/vendor/metax/metax.py
@@ -14,7 +14,7 @@ import inspect
 
 import torch
 
-from ....ops import TEFLBackendBase, FP8TensorMeta
+from ....ops import *
 
 def _load_metax_libs():
 
@@ -74,67 +74,6 @@ def _get_tex():
     import transformer_engine_torch_metax
     return transformer_engine_torch_metax
 
-def _torch_dtype_to_te_dtype(torch_dtype, tex_module):
-    if torch_dtype is None:
-        return None
-
-    NativeDType = tex_module.DType
-    if type(torch_dtype).__name__ == 'DType' and type(torch_dtype).__module__ == 'transformer_engine_torch_metax':
-        return torch_dtype
-
-    if hasattr(torch_dtype, 'name') and hasattr(torch_dtype, 'value'):
-        from transformer_engine.plugin.core.ops import DType as PyDType
-        if isinstance(torch_dtype, PyDType):
-            dtype_name = torch_dtype.name
-            if hasattr(NativeDType, dtype_name):
-                return getattr(NativeDType, dtype_name)
-
-    dtype_map = {
-        torch.float32: NativeDType.kFloat32,
-        torch.float16: NativeDType.kFloat16,
-        torch.bfloat16: NativeDType.kBFloat16,
-        torch.int32: NativeDType.kInt32,
-        torch.uint8: NativeDType.kByte,
-    }
-
-    if hasattr(torch, 'float8_e4m3fn'):
-        dtype_map[torch.float8_e4m3fn] = NativeDType.kFloat8E4M3
-    if hasattr(torch, 'float8_e5m2'):
-        dtype_map[torch.float8_e5m2] = NativeDType.kFloat8E5M2
-
-    return dtype_map.get(torch_dtype, torch_dtype)
-
-def _convert_dtype_params(func):
-
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        dtype_params = ['otype', 'output_dtype', 'bias_type']
-
-        from transformer_engine.plugin.core.ops import DType as PyDType
-
-        def needs_conversion(val):
-            return isinstance(val, torch.dtype) or isinstance(val, PyDType)
-
-        for param_name in dtype_params:
-            if param_name in kwargs:
-                value = kwargs[param_name]
-                if needs_conversion(value):
-                    converted = self._to_te_dtype(value)
-                    kwargs[param_name] = converted
-
-        sig = inspect.signature(func)
-        param_names = list(sig.parameters.keys())[1:]
-
-        args_list = list(args)
-        for i, (param_name, arg_value) in enumerate(zip(param_names, args_list)):
-            if param_name in dtype_params and needs_conversion(arg_value):
-                converted = self._to_te_dtype(arg_value)
-                args_list[i] = converted
-
-        return func(self, *args_list, **kwargs)
-
-    return wrapper
-
 class MetaxBackend(TEFLBackendBase):
     @staticmethod
     def check_available() -> bool:
@@ -148,15 +87,8 @@ class MetaxBackend(TEFLBackendBase):
             self._tex = _get_tex()
         return self._tex
 
-    def _to_te_dtype(self, torch_dtype):
-        return _torch_dtype_to_te_dtype(torch_dtype, self._get_tex())
-
     def is_available(self) -> bool:
         return _check_metax_available()
-
-    def get_flash_attention_class(self):
-        from .flash_attention import FlashAttentionMETAX
-        return FlashAttentionMETAX
 
     def get_attention_backend(self, attention_params=None):
         # Import the metax get_attention_backend function
@@ -175,6 +107,7 @@ class MetaxBackend(TEFLBackendBase):
                 f"Attention_params: {self.attention_params}"
             )
 
+##### transformer_engine/pytorch/csrc/extensions/pybind.cpp #####
     def quantize(
         self,
         tensor: torch.Tensor,
@@ -185,98 +118,89 @@ class MetaxBackend(TEFLBackendBase):
         tex = self._get_tex()
         return tex.quantize(tensor, quantizer, output, noop)
 
-    @_convert_dtype_params
     def dequantize(
         self,
-        input: torch.Tensor,
-        otype: torch.dtype,
-    ) -> torch.Tensor:
+        input: Any,
+        otype: DType,
+    ) -> Any:
         tex = self._get_tex()
+        otype = tex.DType(int(otype)) if otype is not None else None
         return tex.dequantize(input, otype)
 
     def bgrad_quantize(
         self,
         input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
         return tex.bgrad_quantize(input, quantizer)
 
-    @_convert_dtype_params
     def generic_gemm(
         self,
-        A: torch.Tensor,
-        transA: bool,
-        B: torch.Tensor,
-        transB: bool,
-        D: torch.Tensor,
+        A: Any,
+        transa: bool,
+        B: Any,
+        transb: bool,
+        D: Any,
         quantizer: Any,
-        output_dtype: torch.dtype,
+        out_dtype: Optional[DType],
         bias: Optional[torch.Tensor],
-        bias_type: Any,
+        bias_type: DType,
         gelu: bool,
         gelu_in: Optional[torch.Tensor],
         grad: bool,
         workspace: torch.Tensor,
-        workspace_size: int,
+        workspaceSize: int,
         accumulate: bool,
         use_split_accumulator: bool,
         comm_overlap: Optional[Any] = None,
-        comm_type: Optional[Any] = None,
+        comm_type: Optional[CommOverlapType] = None,
         extra_output: Optional[torch.Tensor] = None,
         bulk_overlap: bool = False,
         alpha: float = 1.0,
         beta: Optional[float] = None,
-    ) -> Any:
+    ) -> List[Any]:
         tex = self._get_tex()
-
-        if bias_type is None:
-            bias_type = self._to_te_dtype(torch.bfloat16)
-
+        
+        bias_type = tex.DType(int(bias_type)) if bias_type is not None else None
+        comm_type = tex.CommOverlapType(int(comm_type)) if comm_type is not None else None
+        out_dtype = tex.DType(int(out_dtype)) if out_dtype is not None else None
         return tex.generic_gemm(
-            A, transA, B, transB, D, quantizer, output_dtype,
-            bias, bias_type, gelu, gelu_in, grad, workspace, workspace_size,
+            A, transa, B, transb, D, quantizer, out_dtype,
+            bias, bias_type, gelu, gelu_in, grad, workspace, workspaceSize,
             accumulate, use_split_accumulator, comm_overlap, comm_type,
             extra_output, bulk_overlap, alpha, beta
         )
-
-    def te_general_grouped_gemm(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.te_general_grouped_gemm(*args, **kwargs)
-
+    # GELU and variants #
     def gelu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.gelu(input, quantizer)
-
     def geglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.geglu(input, quantizer)
     def qgelu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.qgelu(input, quantizer)
-
     def qgeglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.qgeglu(input, quantizer)
+    # ReLU and variants #
     def relu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.relu(input, quantizer)
-
     def reglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.reglu(input, quantizer)
     def srelu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.srelu(input, quantizer)
-
     def sreglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.sreglu(input, quantizer)
-
+    # SwiGLU and variants #
     def silu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.silu(input, quantizer)
-
     def swiglu(self, input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.swiglu(input, quantizer)
@@ -289,42 +213,39 @@ class MetaxBackend(TEFLBackendBase):
     ) -> Any:
         tex = self._get_tex()
         return tex.clamped_swiglu(input, quantizer, limit, alpha)
-
+    # Backward of GELU and variants #
     def dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dgelu(grad, fwd_input, quantizer)
     def dgeglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dgeglu(grad, fwd_input, quantizer)
-
     def dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dqgelu(grad, fwd_input, quantizer)
     def dqgeglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dqgeglu(grad, fwd_input, quantizer)
-
+    # Backward of ReLU and variants #
     def drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.drelu(grad, fwd_input, quantizer)
     def dreglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dreglu(grad, fwd_input, quantizer)
-
     def dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dsrelu(grad, fwd_input, quantizer)
     def dsreglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dsreglu(grad, fwd_input, quantizer)
-
+    # Backward of SiLU and variants #
     def dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dsilu(grad, fwd_input, quantizer)
     def dswiglu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Any:
         tex = self._get_tex()
         return tex.dswiglu(grad, fwd_input, quantizer)
-
     def clamped_dswiglu(
         self,
         grad: torch.Tensor,
@@ -335,28 +256,137 @@ class MetaxBackend(TEFLBackendBase):
     ) -> Any:
         tex = self._get_tex()
         return tex.clamped_dswiglu(grad, fwd_input, quantizer, limit, alpha)
-
+    # DBias + DAct fusions #
     def dbias_dgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dgelu(grad, fwd_input, quantizer)
-
     def dbias_dsilu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dsilu(grad, fwd_input, quantizer)
-
     def dbias_drelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_drelu(grad, fwd_input, quantizer)
-
     def dbias_dqgelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dqgelu(grad, fwd_input, quantizer)
-
     def dbias_dsrelu(self, grad: torch.Tensor, fwd_input: torch.Tensor, quantizer: Any) -> Tuple[torch.Tensor, Any]:
         tex = self._get_tex()
         return tex.dbias_dsrelu(grad, fwd_input, quantizer)
-
-    @_convert_dtype_params
+    # Permutation functions                                                                                                                                                                                                                                                                                             
+    def moe_permute_fwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        indices: torch.Tensor,
+        num_out_tokens: int,
+        workspace: List[torch.Tensor],
+        max_expanded_token_num: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, List[torch.Tensor]]:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_permute_fwd(input, dtype,indices,num_out_tokens,workspace,max_expanded_token_num)
+    def moe_permute_bwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+        num_tokens: int,
+        topK: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_permute_bwd(input,dtype,row_id_map,prob,num_tokens,topK)
+    def moe_unpermute_fwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+        num_tokens: int,
+        topK: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_unpermute_fwd(input,dtype,row_id_map,prob,num_tokens,topK)
+    def moe_unpermute_bwd(
+        self,
+        input_bwd: torch.Tensor,
+        input_fwd: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        dtype = tex.DType(int(dtype)) if dtype is not None else None
+        return tex.moe_unpermute_bwd(input_bwd,input_fwd,dtype,row_id_map,prob)
+    # Softmax functions
+    def scaled_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_softmax_forward(input, scale)
+    def scaled_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_softmax_backward(output_grad_, softmax_results_, scale_factor)
+    def scaled_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        mask: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_masked_softmax_forward(input, mask, scale_factor)
+    def scaled_masked_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_masked_softmax_backward(output_grad_, softmax_results_, scale_factor)
+    def scaled_upper_triang_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_upper_triang_masked_softmax_forward(input, scale_factor)
+    def scaled_upper_triang_masked_softmax_backward(
+        self,
+        output_grads_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_upper_triang_masked_softmax_backward(
+            output_grads_, softmax_results_, scale_factor
+        )
+    def scaled_aligned_causal_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_aligned_causal_masked_softmax_forward(input, scale_factor)
+    def scaled_aligned_causal_masked_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.scaled_aligned_causal_masked_softmax_backward(
+            output_grad_, softmax_results_, scale_factor
+        )
+    # Other granular functions
     def layernorm_fwd(
         self,
         input: torch.Tensor,
@@ -365,27 +395,18 @@ class MetaxBackend(TEFLBackendBase):
         eps: float,
         ln_out: Optional[torch.Tensor],
         quantizer: Any,
-        otype: torch.dtype,
+        otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = input.shape
-        if input.ndim > 2:
-            input = input.view(-1, input.shape[-1])
-
-        y, mu, rsigma = tex.layernorm_fwd(
+        otype = tex.DType(int(otype)) if otype is not None else None
+        return tex.layernorm_fwd(
             input, weight, bias, eps, ln_out, quantizer, otype, sm_margin, zero_centered_gamma
         )
-
-        if len(orig_shape) > 2:
-            y = y.view(*orig_shape)
-        return y, mu, rsigma
-
     def layernorm_bwd(
         self,
-        dy: torch.Tensor,
+        dz: torch.Tensor,
         x: torch.Tensor,
         mu: torch.Tensor,
         rsigma: torch.Tensor,
@@ -394,19 +415,9 @@ class MetaxBackend(TEFLBackendBase):
         zero_centered_gamma: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = dy.shape
-        if dy.ndim > 2:
-            dy = dy.view(-1, dy.shape[-1])
-            x = x.view(-1, x.shape[-1])
-
-        dx, dgamma, dbeta = tex.layernorm_bwd(dy, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma)
-
-        if len(orig_shape) > 2:
-            dx = dx.view(*orig_shape)
-        return dx, dgamma, dbeta
-
-    @_convert_dtype_params
+        return tex.layernorm_bwd(
+            dz, x, mu, rsigma, gamma, sm_margin, zero_centered_gamma
+        )
     def rmsnorm_fwd(
         self,
         input: torch.Tensor,
@@ -414,52 +425,38 @@ class MetaxBackend(TEFLBackendBase):
         eps: float,
         ln_out: Optional[torch.Tensor],
         quantizer: Any,
-        otype: torch.dtype,
+        otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = input.shape
-        if input.ndim > 2:
-            input = input.view(-1, input.shape[-1])
-
-        y, y_quant, rsigma = tex.rmsnorm_fwd(
+        otype = tex.DType(int(otype)) if otype is not None else None
+        return tex.rmsnorm_fwd(
             input, weight, eps, ln_out, quantizer, otype, sm_margin, zero_centered_gamma
         )
-
-        if len(orig_shape) > 2:
-            y = y.view(*orig_shape)
-            if y_quant is not None:
-                y_quant = y_quant.view(*orig_shape)
-        return y, y_quant, rsigma
-
     def rmsnorm_bwd(
         self,
-        dy: torch.Tensor,
+        dz: torch.Tensor,
         x: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
         sm_margin: int = 0,
         zero_centered_gamma: bool = False,
-        eps: float = 1e-5,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-
-        orig_shape = dy.shape
-        if dy.ndim > 2:
-            dy = dy.view(-1, dy.shape[-1])
-            x = x.view(-1, x.shape[-1])
-
-        dx, dw = tex.rmsnorm_bwd(dy, x, rsigma, gamma, sm_margin, zero_centered_gamma)
-
-        if len(orig_shape) > 2:
-            dx = dx.view(*orig_shape)
-        return dx, dw
-
-    def rmsnorm_bwd_add(self, *args, **kwargs) -> Any:
+        return tex.rmsnorm_bwd(dz, x, rsigma, gamma, sm_margin, zero_centered_gamma)
+    def rmsnorm_bwd_add(
+        self,
+        dz: torch.Tensor,
+        x: torch.Tensor,
+        add: torch.Tensor,
+        rsigma: torch.Tensor,
+        gamma: torch.Tensor,
+        sm_margin: int = 0,
+        zero_centered_gamma: bool = False,
+    ) -> Any:
         tex = self._get_tex()
-        return tex.rmsnorm_bwd_add(*args, **kwargs)
+        return tex.rmsnorm_bwd_add(dz, x, add, rsigma, gamma, sm_margin, zero_centered_gamma)
 
     def multi_tensor_quantize(
         self,
@@ -468,7 +465,6 @@ class MetaxBackend(TEFLBackendBase):
     ) -> List[Any]:
         tex = self._get_tex()
         return tex.multi_tensor_quantize(tensor_list, quantizer_list)
-
     def split_quantize(
         self,
         tensor: torch.Tensor,
@@ -477,354 +473,86 @@ class MetaxBackend(TEFLBackendBase):
     ) -> List[Any]:
         tex = self._get_tex()
         return tex.split_quantize(tensor, split_sections, quantizer_list)
-
-    def moe_permute_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.moe_permute_fwd(*args, **kwargs)
-
-    def moe_permute_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.moe_permute_bwd(*args, **kwargs)
-
-    def moe_unpermute_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.moe_unpermute_fwd(*args, **kwargs)
-
-    def moe_unpermute_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.moe_unpermute_bwd(*args, **kwargs)
-
-    def scaled_softmax_forward(self, input: torch.Tensor, scale: float) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_softmax_forward(input, scale)
-
-    def scaled_softmax_backward(
+    def te_general_grouped_gemm(
         self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
+        A: torch.Tensor,
+        transa: bool,
+        B: torch.Tensor,
+        transb: bool,
+        D: Optional[List[torch.Tensor]],
+        D_type: DType,
+        m_splits: List[int],
+        bias: List[torch.Tensor],
+        bias_type: DType,
+        single_output: bool,
+        pre_gelu_out: List[torch.Tensor],
+        grad: bool,
+        workspace: List[torch.Tensor],
+        workspaceSizes: int,
+        accumulate: bool,
+        use_split_accumulator: bool,
+        math_sm_count: int,
+    ) -> Optional[List[torch.Tensor]]:
         tex = self._get_tex()
-        return tex.scaled_softmax_backward(output_grad, softmax_output, scale)
-
-    def scaled_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        mask: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_masked_softmax_forward(input, mask, scale)
-
-    def scaled_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_masked_softmax_backward(output_grad, softmax_output, scale)
-
-    def scaled_upper_triang_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_upper_triang_masked_softmax_forward(input, scale)
-
-    def scaled_upper_triang_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_upper_triang_masked_softmax_backward(output_grad, softmax_output, scale)
-
-    def scaled_aligned_causal_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_aligned_causal_masked_softmax_forward(input, scale)
-
-    def scaled_aligned_causal_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.scaled_aligned_causal_masked_softmax_backward(output_grad, softmax_output, scale)
-
-    def get_fused_attn_backend(self, *args, **kwargs) -> int:
-        tex = self._get_tex()
-
-        args_list = list(args)
-
-        def convert_enum(py_enum, native_enum_class):
-            if py_enum is None:
-                return None
-
-            if type(py_enum).__module__ == 'transformer_engine_torch_metax':
-                return py_enum
-
-            if hasattr(py_enum, 'name'):
-                enum_name = py_enum.name
-                if hasattr(native_enum_class, enum_name):
-                    return getattr(native_enum_class, enum_name)
-
-            if hasattr(py_enum, 'value'):
-                enum_value = int(py_enum.value)
-                for member_name in dir(native_enum_class):
-                    if not member_name.startswith('_'):
-                        try:
-                            member = getattr(native_enum_class, member_name)
-                            if hasattr(member, 'value') and int(member.value) == enum_value:
-                                return member
-                        except:
-                            pass
-
-            if hasattr(py_enum, 'value'):
-                return int(py_enum.value)
-
-            return py_enum
-
-        if len(args) > 1:
-            args_list[1] = self._to_te_dtype(args[1])
-        if len(args) > 2:
-            args_list[2] = self._to_te_dtype(args[2])
-        if len(args) > 3:
-            args_list[3] = convert_enum(args[3], tex.NVTE_QKV_Layout)
-        if len(args) > 4:
-            args_list[4] = convert_enum(args[4], tex.NVTE_Bias_Type)
-        if len(args) > 5:
-            args_list[5] = convert_enum(args[5], tex.NVTE_Mask_Type)
-        if len(args) > 6:
-            args_list[6] = convert_enum(args[6], tex.NVTE_Softmax_Type)
-
-        return tex.get_fused_attn_backend(*args_list, **kwargs)
-
-    def fused_attn_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-
-        def convert_enum(py_enum, native_enum_class):
-            if py_enum is None:
-                return None
-            if type(py_enum).__module__ == 'transformer_engine_torch_metax':
-                return py_enum
-            if hasattr(py_enum, 'name'):
-                enum_name = py_enum.name
-                if hasattr(native_enum_class, enum_name):
-                    return getattr(native_enum_class, enum_name)
-            return py_enum
-
-        args_list = list(args)
-        if len(args) > 6:
-            args_list[6] = convert_enum(args[6], tex.NVTE_QKV_Layout)
-        if len(args) > 7:
-            args_list[7] = convert_enum(args[7], tex.NVTE_Bias_Type)
-        if len(args) > 8:
-            args_list[8] = convert_enum(args[8], tex.NVTE_Mask_Type)
-        if len(args) > 9:
-            args_list[9] = convert_enum(args[9], tex.NVTE_Softmax_Type)
-
-        return tex.fused_attn_fwd(*args_list, **kwargs)
-
-    def fused_attn_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-
-        def convert_enum(py_enum, native_enum_class):
-            if py_enum is None:
-                return None
-            if type(py_enum).__module__ == 'transformer_engine_torch_metax':
-                return py_enum
-            if hasattr(py_enum, 'name'):
-                enum_name = py_enum.name
-                if hasattr(native_enum_class, enum_name):
-                    return getattr(native_enum_class, enum_name)
-            return py_enum
-
-        args_list = list(args)
-        if len(args) > 5:
-            args_list[5] = convert_enum(args[5], tex.NVTE_QKV_Layout)
-        if len(args) > 6:
-            args_list[6] = convert_enum(args[6], tex.NVTE_Bias_Type)
-        if len(args) > 7:
-            args_list[7] = convert_enum(args[7], tex.NVTE_Mask_Type)
-        if len(args) > 8:
-            args_list[8] = convert_enum(args[8], tex.NVTE_Softmax_Type)
-        if len(args) > 19:
-            args_list[19] = self._to_te_dtype(args[19])
-
-        if 'dqkv_dtype' in kwargs:
-            kwargs['dqkv_dtype'] = self._to_te_dtype(kwargs['dqkv_dtype'])
-
-        return tex.fused_attn_bwd(*args_list, **kwargs)
-
-    def fa_prepare_fwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fa_prepare_fwd(*args, **kwargs)
-
-    def fa_prepare_bwd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fa_prepare_bwd(*args, **kwargs)
-
-    def copy_to_kv_cache(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.copy_to_kv_cache(*args, **kwargs)
-
-    def convert_thd_to_bshd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.convert_thd_to_bshd(*args, **kwargs)
-
-    def convert_bshd_to_thd(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.convert_bshd_to_thd(*args, **kwargs)
-
-    def fused_rope_forward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_rope_forward(*args, **kwargs)
-
-    def fused_rope_backward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_rope_backward(*args, **kwargs)
-
-    def fused_qkv_rope_forward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_qkv_rope_forward(*args, **kwargs)
-
-    def fused_qkv_rope_backward(self, *args, **kwargs) -> Any:
-        tex = self._get_tex()
-        return tex.fused_qkv_rope_backward(*args, **kwargs)
-
-    def fused_topk_with_score_function_fwd(
-        self,
-        logits: torch.Tensor,
-        topk: int,
-        use_pre_softmax: bool,
-        num_groups: int,
-        group_topk: int,
-        scaling_factor: float,
-        score_function: Any,
-        expert_bias: Optional[torch.Tensor],
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_topk_with_score_function_fwd(
-            logits, topk, use_pre_softmax, num_groups, group_topk,
-            scaling_factor, score_function, expert_bias
+        D_type = tex.DType(int(D_type)) if D_type is not None else None
+        bias_type = tex.DType(int(bias_type)) if bias_type is not None else None
+        return tex.te_general_grouped_gemm(
+            A, transa, B, transb, D, D_type, m_splits, bias, bias_type,
+            single_output, pre_gelu_out, grad, workspace, workspaceSizes,
+            accumulate, use_split_accumulator, math_sm_count
         )
-
-    def fused_topk_with_score_function_bwd(
-        self,
-        num_tokens: int,
-        num_experts: int,
-        routing_map: torch.Tensor,
-        intermediate_output: torch.Tensor,
-        grad_probs: torch.Tensor,
-        topk: int,
-        use_pre_softmax: bool,
-        scaling_factor: float,
-        score_function: Any,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_topk_with_score_function_bwd(
-            num_tokens, num_experts, routing_map, intermediate_output,
-            grad_probs, topk, use_pre_softmax, scaling_factor, score_function
-        )
-
-    def fused_score_for_moe_aux_loss_fwd(
-        self,
-        logits: torch.Tensor,
-        topk: int,
-        score_function: Any,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_score_for_moe_aux_loss_fwd(logits, topk, score_function)
-
-    def fused_score_for_moe_aux_loss_bwd(
-        self,
-        num_tokens: int,
-        num_experts: int,
-        intermediate_output: torch.Tensor,
-        grad_scores: torch.Tensor,
-        topk: int,
-        score_function: Any,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_score_for_moe_aux_loss_bwd(
-            num_tokens, num_experts, intermediate_output, grad_scores, topk, score_function
-        )
-
-    def fused_moe_aux_loss_fwd(
-        self,
-        probs: torch.Tensor,
-        tokens_per_expert: torch.Tensor,
-        total_num_tokens: int,
-        num_experts: int,
-        num_rows: int,
-        num_cols: int,
-        topk: int,
-        coeff: float,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_moe_aux_loss_fwd(
-            probs, tokens_per_expert, total_num_tokens, num_experts,
-            num_rows, num_cols, topk, coeff
-        )
-
-    def fused_moe_aux_loss_bwd(
-        self,
-        Const_buf: torch.Tensor,
-        tokens_per_expert: torch.Tensor,
-        num_rows: int,
-        num_cols: int,
-        grad_aux_loss: torch.Tensor,
-    ) -> Any:
-        tex = self._get_tex()
-        return tex.fused_moe_aux_loss_bwd(
-            Const_buf, tokens_per_expert, num_rows, num_cols, grad_aux_loss
-        )
-
-    def dropout_fwd(
-        self,
-        input: torch.Tensor,
-        dropout_probability: float,
-        out: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        tex = self._get_tex()
-        return tex.dropout_fwd(input, dropout_probability, out)
-
-    def dropout_bwd(
-        self,
-        grad_output: torch.Tensor,
-        mask: torch.Tensor,
-        dropout_probability: float,
-        grad_input: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        tex = self._get_tex()
-        return tex.dropout_bwd(grad_output, mask, dropout_probability, grad_input)
-
     def fp8_transpose(
         self,
         input: torch.Tensor,
-        dtype: Any,
-        *,
-        out: torch.Tensor,
-    ) -> None:
+        otype: DType,
+        output: Optional[torch.Tensor],
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        tex.fp8_transpose(input, dtype, out=out)
-
+        otype = tex.DType(int(otype)) if otype is not None else None
+        return tex.fp8_transpose(input, otype, output)
     def swap_first_dims(
         self,
         tensor: torch.Tensor,
-        *,
-        out: torch.Tensor,
-    ) -> None:
+        out: Optional[torch.Tensor],
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        tex.swap_first_dims(tensor, out=out)
+        return tex.swap_first_dims(tensor, out)
+    def get_fused_attn_backend(
+        self,
+        is_training: bool,
+        q_dtype: DType,
+        kv_dtype: DType,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        p_dropout: float,
+        num_attn_heads: int,
+        num_gqa_groups: int,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        head_dim_qk: int,
+        head_dim_v: int,
+        window_size_left: int,
+        window_size_right: int,
+        return_max_logit: bool,
+    ) -> NVTE_Fused_Attn_Backend:
+        tex = self._get_tex()
+
+        q_dtype = tex.DType(int(q_dtype)) if q_dtype is not None else None
+        kv_dtype = tex.DType(int(kv_dtype)) if kv_dtype is not None else None
+        qkv_layout = tex.NVTE_QKV_Layout(int(qkv_layout)) if qkv_layout is not None else None
+        bias_type = tex.NVTE_Bias_Type(int(bias_type)) if bias_type is not None else None
+        attn_mask_type = tex.NVTE_Mask_Type(int(attn_mask_type)) if attn_mask_type is not None else None
+        softmax_type = tex.NVTE_Softmax_Type(int(softmax_type)) if softmax_type is not None else None
+
+        result = tex.get_fused_attn_backend(
+            is_training, q_dtype, kv_dtype, qkv_layout, bias_type,
+            attn_mask_type, softmax_type, p_dropout, num_attn_heads,
+            num_gqa_groups, max_seqlen_q, max_seqlen_kv, head_dim_qk,
+            head_dim_v, window_size_left, window_size_right, return_max_logit
+        )
+        return NVTE_Fused_Attn_Backend(result)
 
     def compute_amax(
         self,
@@ -832,12 +560,22 @@ class MetaxBackend(TEFLBackendBase):
         amax: torch.Tensor,
     ) -> None:
         tex = self._get_tex()
-        tex.compute_amax(input, amax)
-
-    def fused_amax_and_scale_update_after_reduction(self, *args, **kwargs) -> None:
+        return tex.compute_amax(input, amax)
+    def fused_amax_and_scale_update_after_reduction(
+        self,
+        amax_reduction_buffer: torch.Tensor,
+        amax_histories: List[torch.Tensor],
+        scales: List[torch.Tensor],
+        amax_compute_algo: str,
+        fp8_dtype: DType,
+        margin: float,
+    ) -> None:
         tex = self._get_tex()
-        tex.fused_amax_and_scale_update_after_reduction(*args, **kwargs)
-
+        fp8_dtype = tex.DType(int(fp8_dtype)) if fp8_dtype is not None else None
+        return tex.fused_amax_and_scale_update_after_reduction(
+            amax_reduction_buffer, amax_histories, scales,
+            amax_compute_algo, fp8_dtype, margin
+        )
     def fp8_block_scaling_compute_partial_amax(
         self,
         tensor: torch.Tensor,
@@ -848,8 +586,9 @@ class MetaxBackend(TEFLBackendBase):
         block_len: int,
     ) -> None:
         tex = self._get_tex()
-        tex.fp8_block_scaling_compute_partial_amax(tensor, amax, h, w, start_offset, block_len)
-
+        return tex.fp8_block_scaling_compute_partial_amax(
+            tensor, amax, h, w, start_offset, block_len
+        )
     def fp8_block_scaling_partial_cast(
         self,
         inp: torch.Tensor,
@@ -859,75 +598,555 @@ class MetaxBackend(TEFLBackendBase):
         w: int,
         start_offset: int,
         block_len: int,
-        out_dtype: Any,
+        out_dtype: DType,
     ) -> None:
         tex = self._get_tex()
-        tex.fp8_block_scaling_partial_cast(inp, out, scale, h, w, start_offset, block_len, out_dtype)
-
-    def fused_multi_row_padding(self, *args, **kwargs) -> Any:
+        out_dtype = tex.DType(int(out_dtype)) if out_dtype is not None else None
+        return tex.fp8_block_scaling_partial_cast(
+            inp, out, scale, h, w, start_offset, block_len, out_dtype
+        )
+    def fused_multi_row_padding(
+        self,
+        input: torch.Tensor,
+        output: torch.Tensor,
+        input_row_list: List[int],
+        padded_input_row_list: List[int],
+    ) -> None:
         tex = self._get_tex()
-        return tex.fused_multi_row_padding(*args, **kwargs)
-
-    def fused_multi_row_unpadding(self, *args, **kwargs) -> Any:
+        return tex.fused_multi_row_padding(
+            input, output, input_row_list, padded_input_row_list
+        )
+    def fused_multi_row_unpadding(
+        self,
+        input: torch.Tensor,
+        output: torch.Tensor,
+        input_row_list: List[int],
+        unpadded_input_row_list: List[int],
+    ) -> None:
         tex = self._get_tex()
-        return tex.fused_multi_row_unpadding(*args, **kwargs)
+        return tex.fused_multi_row_unpadding(
+            input, output, input_row_list, unpadded_input_row_list
+        )
 
+    # attention kernels
+    def fa_prepare_fwd(
+        self,
+        qkvi: torch.Tensor,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fa_prepare_fwd(qkvi)
+    def fa_prepare_bwd(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fa_prepare_bwd(q, k, v)
+    def fused_attn_fwd(
+        self,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        is_training: bool,
+        attn_scale: float,
+        p_dropout: float,
+        set_zero: bool,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        window_size: List[int],
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_kv: torch.Tensor,
+        Q: Any,
+        K: Any,
+        V: Any,
+        fake_dtype: torch.dtype,
+        cu_seqlens_q_padded: Optional[torch.Tensor],
+        cu_seqlens_kv_padded: Optional[torch.Tensor],
+        page_table_k: Optional[torch.Tensor],
+        page_table_v: Optional[torch.Tensor],
+        s_quantizer: Any,
+        o_quantizer: Any,
+        Bias: Optional[torch.Tensor],
+        SoftmaxOffset: Optional[torch.Tensor],
+        rng_gen: Optional[torch.Generator],
+        rng_elts_per_thread: int,
+        return_max_logit: bool,
+    ) -> List[Any]:
+        tex = self._get_tex()
+
+        qkv_layout = tex.NVTE_QKV_Layout(int(qkv_layout)) if qkv_layout is not None else None
+        bias_type = tex.NVTE_Bias_Type(int(bias_type)) if bias_type is not None else None
+        attn_mask_type = tex.NVTE_Mask_Type(int(attn_mask_type)) if attn_mask_type is not None else None
+        softmax_type = tex.NVTE_Softmax_Type(int(softmax_type)) if softmax_type is not None else None
+
+        return tex.fused_attn_fwd(
+            max_seqlen_q,
+            max_seqlen_kv,
+            is_training,
+            attn_scale,
+            p_dropout,
+            set_zero,
+            qkv_layout,
+            bias_type,
+            attn_mask_type,
+            softmax_type,
+            window_size,
+            cu_seqlens_q,
+            cu_seqlens_kv,
+            Q,
+            K,
+            V,
+            fake_dtype,
+            cu_seqlens_q_padded,
+            cu_seqlens_kv_padded,
+            page_table_k,
+            page_table_v,
+            s_quantizer,
+            o_quantizer,
+            Bias,
+            SoftmaxOffset,
+            rng_gen,
+            rng_elts_per_thread,
+            return_max_logit
+        )
+    def fused_attn_bwd(
+        self,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        attn_scale: float,
+        p_dropout: float,
+        set_zero: bool,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        window_size: List[int],
+        deterministic: bool,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_kv: torch.Tensor,
+        Q: Any,
+        K: Any,
+        V: Any,
+        O: Any,
+        dO: Any,
+        fake_dtype: torch.dtype,
+        dqkv_type: DType,
+        Aux_CTX_Tensors: List[torch.Tensor],
+        cu_seqlens_q_padded: Optional[torch.Tensor],
+        cu_seqlens_kv_padded: Optional[torch.Tensor],
+        s_quantizer: Any,
+        dp_quantizer: Any,
+        dqkv_quantizer: Any,
+    ) -> List[Any]:
+        tex = self._get_tex()
+
+        qkv_layout = tex.NVTE_QKV_Layout(int(qkv_layout)) if qkv_layout is not None else None
+        bias_type = tex.NVTE_Bias_Type(int(bias_type)) if bias_type is not None else None
+        attn_mask_type = tex.NVTE_Mask_Type(int(attn_mask_type)) if attn_mask_type is not None else None
+        softmax_type = tex.NVTE_Softmax_Type(int(softmax_type)) if softmax_type is not None else None
+        dqkv_type = tex.DType(int(dqkv_type)) if dqkv_type is not None else None
+
+        return tex.fused_attn_bwd(
+            max_seqlen_q,
+            max_seqlen_kv,
+            attn_scale,
+            p_dropout,
+            set_zero,
+            qkv_layout,
+            bias_type,
+            attn_mask_type,
+            softmax_type,
+            window_size,
+            deterministic,
+            cu_seqlens_q,
+            cu_seqlens_kv,
+            Q,
+            K,
+            V,
+            O,
+            dO,
+            fake_dtype,
+            dqkv_type,
+            Aux_CTX_Tensors,
+            cu_seqlens_q_padded,
+            cu_seqlens_kv_padded,
+            s_quantizer,
+            dp_quantizer,
+            dqkv_quantizer
+        )
+    def copy_to_kv_cache(
+        self,
+        new_k: torch.Tensor,
+        new_v: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        page_table: torch.Tensor,
+        cu_new_lens: torch.Tensor,
+        cu_cached_lens: torch.Tensor,
+        qkv_format: NVTE_QKV_Format,
+        b: int,
+        max_ctx_len: int,
+        max_seq_len: int,
+        max_pages_per_seq: int,
+        is_non_paged: bool,
+    ) -> None:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.copy_to_kv_cache(
+            new_k,
+            new_v,
+            k_cache,
+            v_cache,
+            page_table,
+            cu_new_lens,
+            cu_cached_lens,
+            qkv_format,
+            b,
+            max_ctx_len,
+            max_seq_len,
+            max_pages_per_seq,
+            is_non_paged
+        )
+    def convert_thd_to_bshd(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        b: int,
+        max_seq_len: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.convert_thd_to_bshd(tensor, cu_seqlens, b, max_seq_len)
+    def convert_bshd_to_thd(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        t: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.convert_bshd_to_thd(tensor, cu_seqlens, t)
+
+    # fused apply rope
+    def fused_rope_forward(
+        self,
+        input: torch.Tensor,
+        freqs: torch.Tensor,
+        start_positions: Optional[torch.Tensor],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cu_seqlens: Optional[torch.Tensor],
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_rope_forward(
+            input, freqs, start_positions, qkv_format,
+            interleaved, cu_seqlens, cp_size, cp_rank
+        )
+    def fused_rope_backward(
+        self,
+        output_grads: torch.Tensor,
+        freqs: torch.Tensor,
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cu_seqlens: Optional[torch.Tensor],
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_rope_backward(
+            output_grads, freqs, qkv_format,
+            interleaved, cu_seqlens, cp_size, cp_rank
+        )
+    def fused_qkv_rope_forward(
+        self,
+        qkv_input: torch.Tensor,
+        q_freqs: torch.Tensor,
+        k_freqs: torch.Tensor,
+        start_positions: Optional[torch.Tensor],
+        qkv_split_arg_list: List[int],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cp_size: int,
+        cp_rank: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_qkv_rope_forward(
+            qkv_input, q_freqs, k_freqs, start_positions,
+            qkv_split_arg_list, qkv_format, interleaved,
+            cp_size, cp_rank
+        )
+    def fused_qkv_rope_backward(
+        self,
+        q_grad_out: torch.Tensor,
+        k_grad_out: torch.Tensor,
+        v_grad_out: torch.Tensor,
+        q_freqs: torch.Tensor,
+        k_freqs: torch.Tensor,
+        qkv_split_arg_list: List[int],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        qkv_format = tex.NVTE_QKV_Format(int(qkv_format)) if qkv_format is not None else None
+        return tex.fused_qkv_rope_backward(
+            q_grad_out, k_grad_out, v_grad_out,
+            q_freqs, k_freqs, qkv_split_arg_list,
+            qkv_format, interleaved, cp_size, cp_rank
+        )
+
+    # fused router
+    def fused_topk_with_score_function_fwd(
+        self,
+        logits: torch.Tensor,
+        topk: int,
+        use_pre_softmax: bool,
+        num_groups: Optional[int],
+        group_topk: Optional[int],
+        scaling_factor: Optional[float],
+        score_function: str,
+        expert_bias: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.fused_topk_with_score_function_fwd(
+            logits,
+            topk,
+            use_pre_softmax,
+            num_groups,
+            group_topk,
+            scaling_factor,
+            score_function,
+            expert_bias,
+        )
+    def fused_topk_with_score_function_bwd(
+        self,
+        num_tokens: int,
+        num_experts: int,
+        routing_map: torch.Tensor,
+        intermediate_output: torch.Tensor,
+        grad_probs: torch.Tensor,
+        topk: int,
+        use_pre_softmax: bool,
+        scaling_factor: Optional[float],
+        score_function: str,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fused_topk_with_score_function_bwd(
+            num_tokens,
+            num_experts,
+            routing_map,
+            intermediate_output,
+            grad_probs,
+            topk,
+            use_pre_softmax,
+            scaling_factor,
+            score_function,
+        )
+    def fused_score_for_moe_aux_loss_fwd(
+        self,
+        logits: torch.Tensor,
+        topk: int,
+        score_function: str,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.fused_score_for_moe_aux_loss_fwd(
+            logits,
+            topk,
+            score_function,
+        )
+    def fused_score_for_moe_aux_loss_bwd(
+        self,
+        num_tokens: int,
+        num_experts: int,
+        intermediate_output: torch.Tensor,
+        grad_scores: torch.Tensor,
+        topk: int,
+        score_function: str,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fused_score_for_moe_aux_loss_bwd(
+            num_tokens,
+            num_experts,
+            intermediate_output,
+            grad_scores,
+            topk,
+            score_function,
+        )
+    def fused_moe_aux_loss_fwd(
+        self,
+        probs: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        total_num_tokens: int,
+        num_experts: int,
+        num_rows: int,
+        num_cols: int,
+        topk: int,
+        coeff: float,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.fused_moe_aux_loss_fwd(
+            probs,
+            tokens_per_expert,
+            total_num_tokens,
+            num_experts,
+            num_rows,
+            num_cols,
+            topk,
+            coeff,
+        )
+    def fused_moe_aux_loss_bwd(
+        self,
+        Const_buf: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        num_rows: int,
+        num_cols: int,
+        grad_aux_loss: torch.Tensor,
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.fused_moe_aux_loss_bwd(Const_buf, tokens_per_expert, num_rows, num_cols, grad_aux_loss)
+
+    # Dropout
+    def dropout_fwd(
+        self,
+        input: torch.Tensor,
+        dropout_probability: float,
+        out: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tex = self._get_tex()
+        return tex.dropout_fwd(input, dropout_probability, out)
+    def dropout_bwd(
+        self,
+        grad_output: torch.Tensor,
+        mask: torch.Tensor,
+        dropout_probability: float,
+        grad_input: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        tex = self._get_tex()
+        return tex.dropout_bwd(grad_output, mask, dropout_probability, grad_input)
+
+    # Misc
     def get_cublasLt_version(self) -> int:
         tex = self._get_tex()
         return tex.get_cublasLt_version()
-
     def get_cudnn_version(self) -> int:
         tex = self._get_tex()
         return tex.get_cudnn_version()
-
     def get_num_cublas_streams(self) -> int:
         tex = self._get_tex()
         return tex.get_num_cublas_streams()
 
-    def thd_read_half_tensor(self, *args, **kwargs) -> Any:
+    # Support THD format for Context Parallel
+    def thd_read_half_tensor(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        half_idx: int,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.thd_read_half_tensor(*args, **kwargs)
-
-    def thd_second_half_lse_correction(self, *args, **kwargs) -> Any:
+        return tex.thd_read_half_tensor(tensor, cu_seqlens, half_idx)
+    def thd_second_half_lse_correction(
+        self,
+        lse: torch.Tensor,
+        lse_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        lse_packed: bool,
+    ) -> None:
         tex = self._get_tex()
-        return tex.thd_second_half_lse_correction(*args, **kwargs)
-
-    def thd_read_second_half_lse(self, *args, **kwargs) -> Any:
+        return tex.thd_second_half_lse_correction(
+            lse, lse_per_step, cu_seqlens, lse_packed
+        )
+    def thd_read_second_half_lse(
+        self,
+        lse: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        lse_packed: bool,
+        second_half_lse_seqlen: int,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.thd_read_second_half_lse(*args, **kwargs)
-
-    def thd_out_correction(self, *args, **kwargs) -> Any:
+        return tex.thd_read_second_half_lse(
+            lse, cu_seqlens, lse_packed, second_half_lse_seqlen
+        )
+    def thd_out_correction(
+        self,
+        out: torch.Tensor,
+        out_per_step: torch.Tensor,
+        lse: torch.Tensor,
+        lse_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        only_second_half: bool,
+        lse_packed: bool,
+    ) -> None:
         tex = self._get_tex()
-        return tex.thd_out_correction(*args, **kwargs)
-
-    def thd_grad_correction(self, *args, **kwargs) -> Any:
+        return tex.thd_out_correction(
+            out, out_per_step, lse, lse_per_step,
+            cu_seqlens, only_second_half, lse_packed
+        )
+    def thd_grad_correction(
+        self,
+        grad: torch.Tensor,
+        grad_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        first_half: str,
+        second_half: str,
+    ) -> None:
         tex = self._get_tex()
-        return tex.thd_grad_correction(*args, **kwargs)
-
-    def thd_get_partitioned_indices(self, *args, **kwargs) -> Any:
+        return tex.thd_grad_correction(
+            grad, grad_per_step, cu_seqlens,
+            first_half, second_half
+        )
+    def thd_get_partitioned_indices(
+        self,
+        cu_seqlens: torch.Tensor,
+        total_tokens: int,
+        world_size: int,
+        rank: int,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.thd_get_partitioned_indices(*args, **kwargs)
+        return tex.thd_get_partitioned_indices(
+            cu_seqlens, total_tokens, world_size, rank
+        )
 
-    def init_nvshmem_backend(self, *args, **kwargs) -> None:
+    # nvshmem functions
+    def init_nvshmem_backend(
+        self,
+        process_group: Any,
+    ) -> None:
         tex = self._get_tex()
-        tex.init_nvshmem_backend(*args, **kwargs)
-
-    def create_nvshmem_tensor(self, *args, **kwargs) -> torch.Tensor:
+        return tex.init_nvshmem_backend(process_group)
+    def create_nvshmem_tensor(
+        self,
+        shape: List[int],
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
         tex = self._get_tex()
-        return tex.create_nvshmem_tensor(*args, **kwargs)
-
-    def nvshmem_send_on_current_stream(self, *args, **kwargs) -> None:
+        return tex.create_nvshmem_tensor(shape, dtype)
+    def nvshmem_send_on_current_stream(
+        self,
+        src: torch.Tensor,
+        dst: torch.Tensor,
+        peer: int,
+        signal: torch.Tensor,
+    ) -> None:
         tex = self._get_tex()
-        tex.nvshmem_send_on_current_stream(*args, **kwargs)
-
-    def nvshmem_wait_on_current_stream(self, *args, **kwargs) -> None:
+        return tex.nvshmem_send_on_current_stream(src, dst, peer, signal)
+    def nvshmem_wait_on_current_stream(
+        self,
+        signal: torch.Tensor,
+        wait_kind: str,
+    ) -> None:
         tex = self._get_tex()
-        tex.nvshmem_wait_on_current_stream(*args, **kwargs)
-
+        return tex.nvshmem_wait_on_current_stream(signal, wait_kind)
     def nvshmem_finalize(self) -> None:
         tex = self._get_tex()
-        tex.nvshmem_finalize()
+        return tex.nvshmem_finalize()
 
+    # multi-tensor functions
     def multi_tensor_scale(
         self,
         chunk_size: int,
@@ -936,98 +1155,195 @@ class MetaxBackend(TEFLBackendBase):
         scale: float,
     ) -> None:
         tex = self._get_tex()
-        tex.multi_tensor_scale(chunk_size, noop_flag, tensor_lists, scale)
-
+        return tex.multi_tensor_scale(chunk_size, noop_flag, tensor_lists, scale)
     def multi_tensor_l2norm(
         self,
         chunk_size: int,
         noop_flag: torch.Tensor,
         tensor_lists: List[List[torch.Tensor]],
-        per_tensor: bool = False,
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
+        per_tensor: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
         return tex.multi_tensor_l2norm(chunk_size, noop_flag, tensor_lists, per_tensor)
-
     def multi_tensor_unscale_l2norm(
         self,
         chunk_size: int,
         noop_flag: torch.Tensor,
         tensor_lists: List[List[torch.Tensor]],
-        scale: torch.Tensor,
-        per_tensor: bool = False,
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
+        inv_scale: torch.Tensor,
+        per_tensor: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         tex = self._get_tex()
-        return tex.multi_tensor_unscale_l2norm(chunk_size, noop_flag, tensor_lists, scale, per_tensor)
-
+        return tex.multi_tensor_unscale_l2norm(
+            chunk_size, noop_flag, tensor_lists, inv_scale, per_tensor
+        )
     def multi_tensor_adam(
         self,
-        chunk_size: int = None,
-        noop_flag: torch.Tensor = None,
-        tensor_lists: List[List[torch.Tensor]] = None,
-        lr: float = None,
-        beta1: float = None,
-        beta2: float = None,
-        eps: float = None,
-        step: int = None,
-        mode: int = None,
-        bias_correction: int = None,
-        weight_decay: float = None,
-    ):
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
         tex = self._get_tex()
-        if chunk_size is None:
-            return tex.multi_tensor_adam
-        tex.multi_tensor_adam(
-            chunk_size, noop_flag, tensor_lists, lr, beta1, beta2,
-            eps, step, mode, bias_correction, weight_decay
+        return tex.multi_tensor_adam(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay
+        )
+    def multi_tensor_adam_param_remainder(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_adam_param_remainder(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay
+        )
+    def multi_tensor_adam_fp8(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        fp8_dtype: DType,
+    ) -> None:
+        tex = self._get_tex()
+        fp8_dtype = tex.DType(int(fp8_dtype)) if fp8_dtype is not None else None
+        return tex.multi_tensor_adam_fp8(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
+            fp8_dtype
+        )
+    def multi_tensor_adam_capturable(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: torch.Tensor,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: torch.Tensor,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        inv_scale: torch.Tensor,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_adam_capturable(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
+            inv_scale
+        )
+    def multi_tensor_adam_capturable_master(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: torch.Tensor,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: torch.Tensor,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        inv_scale: torch.Tensor,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_adam_capturable_master(
+            chunk_size, noop_flag, tensor_lists,
+            lr, beta1, beta2, epsilon,
+            step, mode, bias_correction, weight_decay,
+            inv_scale
+        )
+    def multi_tensor_sgd(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        wd: float,
+        momentum: float,
+        dampening: float,
+        lr: float,
+        nesterov: bool,
+        first_run: bool,
+        wd_after_momentum: bool,
+        scale: float,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_sgd(
+            chunk_size, noop_flag, tensor_lists,
+            wd, momentum, dampening,
+            lr, nesterov, first_run,
+            wd_after_momentum, scale
+        )
+    def multi_tensor_compute_scale_and_scale_inv(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        max_fp8: float,
+        force_pow_2_scales: bool,
+        epsilon: float,
+    ) -> None:
+        tex = self._get_tex()
+        return tex.multi_tensor_compute_scale_and_scale_inv(
+            chunk_size, noop_flag, tensor_lists,
+            max_fp8, force_pow_2_scales, epsilon
         )
 
-    def multi_tensor_adam_param_remainder(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_param_remainder(*args, **kwargs)
-
-    def multi_tensor_adam_fp8(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_fp8(*args, **kwargs)
-
-    def multi_tensor_adam_capturable(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_capturable(*args, **kwargs)
-
-    def multi_tensor_adam_capturable_master(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_adam_capturable_master(*args, **kwargs)
-
-    def multi_tensor_sgd(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_sgd(*args, **kwargs)
-
-    def multi_tensor_compute_scale_and_scale_inv(self, *args, **kwargs) -> None:
-        tex = self._get_tex()
-        tex.multi_tensor_compute_scale_and_scale_inv(*args, **kwargs)
-
+    # Comm+GEMM Overlap
     def bulk_overlap_ag_with_external_gemm(
         self,
-        allgather_communicator: Any,
+        allgather_communicator: CommOverlap,
         send_stream: Any,
         recv_stream: Any,
     ) -> Any:
         tex = self._get_tex()
         return tex.bulk_overlap_ag_with_external_gemm(allgather_communicator, send_stream, recv_stream)
 
+############## class func #################################
+    def get_flash_attention_class(self):
+        from .flash_attention import FlashAttentionMETAX
+        return FlashAttentionMETAX
     def create_fp8_tensor_meta(self) -> FP8TensorMeta:
         tex = self._get_tex()
         return tex.FP8TensorMeta()
-
     def create_comm_overlap_helper(
         self,
         world_group: Optional[Any] = None,
         intra_node_group: Optional[Any] = None,
-    ) -> Any:
+    ) -> "CommOverlapHelper":
         tex = self._get_tex()
-        if world_group is None:
-            return tex.CommOverlapHelper()
         return tex.CommOverlapHelper(world_group, intra_node_group)
-
     def create_comm_overlap(
         self,
         buffer_shape: List[int],
@@ -1043,7 +1359,7 @@ class MetaxBackend(TEFLBackendBase):
         set_sm_margin: bool = True,
         atomic_gemm: bool = False,
         rs_overlap_first_gemm: bool = False,
-    ) -> Any:
+    ) -> "CommOverlap":
         tex = self._get_tex()
         return tex.CommOverlap(
             buffer_shape, buffer_dtype, helper, tp_size,
@@ -1051,7 +1367,6 @@ class MetaxBackend(TEFLBackendBase):
             gemm_priority, comm_priority, num_comm_sm,
             set_sm_margin, atomic_gemm, rs_overlap_first_gemm
         )
-
     def create_comm_overlap_p2p(
         self,
         buffer_shape: List[int],
@@ -1068,7 +1383,7 @@ class MetaxBackend(TEFLBackendBase):
         atomic_gemm: bool = False,
         use_ce: bool = True,
         aggregate: bool = False,
-    ) -> Any:
+    ) -> "CommOverlapP2P":
         tex = self._get_tex()
         return tex.CommOverlapP2P(
             buffer_shape, buffer_dtype, helper, tp_size, comm_type,

--- a/transformer_engine/plugin/core/ops.py
+++ b/transformer_engine/plugin/core/ops.py
@@ -382,25 +382,25 @@ class TEFLBackendBase(ABC):
         self,
         input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> List[Any]:
         raise NotImplementedError
 
     def generic_gemm(
         self,
         A: Any,
-        transa: bool,
+        transA: bool,
         B: Any,
-        transb: bool,
+        transB: bool,
         D: Any,
         quantizer: Any,
-        out_dtype: Optional[DType],
+        output_dtype: Optional[DType],
         bias: Optional[torch.Tensor],
         bias_type: DType,
         gelu: bool,
         gelu_in: Optional[torch.Tensor],
         grad: bool,
         workspace: torch.Tensor,
-        workspaceSize: int,
+        workspace_size: int,
         accumulate: bool,
         use_split_accumulator: bool,
         comm_overlap: Optional[Any] = None,
@@ -571,35 +571,35 @@ class TEFLBackendBase(ABC):
         grad: torch.Tensor,
         fwd_input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
+    ) -> List[Any]:
         raise NotImplementedError
     def dbias_dsilu(
         self,
         grad: torch.Tensor,
         fwd_input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
+    ) -> List[Any]:
         raise NotImplementedError
     def dbias_drelu(
         self,
         grad: torch.Tensor,
         fwd_input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
+    ) -> List[Any]:
         raise NotImplementedError
     def dbias_dqgelu(
         self,
         grad: torch.Tensor,
         fwd_input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
+    ) -> List[Any]:
         raise NotImplementedError
     def dbias_dsrelu(
         self,
         grad: torch.Tensor,
         fwd_input: torch.Tensor,
         quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
+    ) -> List[Any]:
         raise NotImplementedError
     # Permutation functions                                                                                                                                                                                                                                                                                             
     def moe_permute_fwd(
@@ -702,12 +702,12 @@ class TEFLBackendBase(ABC):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor],
         eps: float,
-        ln_out: Optional[torch.Tensor],
+        ln_out: Any,
         quantizer: Any,
         otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> List[Any]:
         raise NotImplementedError
     def layernorm_bwd(
         self,
@@ -716,21 +716,21 @@ class TEFLBackendBase(ABC):
         mu: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         raise NotImplementedError
     def rmsnorm_fwd(
         self,
-        input: torch.Tensor,
-        weight: torch.Tensor,
+        input: Any,
+        weight: Any,
         eps: float,
-        ln_out: Optional[torch.Tensor],
+        ln_out: Any,
         quantizer: Any,
         otype: DType,
         sm_margin: int,
         zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    ) -> List[Any]:
         raise NotImplementedError
     def rmsnorm_bwd(
         self,
@@ -738,9 +738,9 @@ class TEFLBackendBase(ABC):
         x: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         raise NotImplementedError
     def rmsnorm_bwd_add(
         self,
@@ -749,9 +749,9 @@ class TEFLBackendBase(ABC):
         add: torch.Tensor,
         rsigma: torch.Tensor,
         gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Any:
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> List[Any]:
         raise NotImplementedError
 
     def multi_tensor_quantize(
@@ -769,9 +769,9 @@ class TEFLBackendBase(ABC):
         raise NotImplementedError
     def te_general_grouped_gemm(
         self,
-        A: torch.Tensor,
+        A: List[Any],
         transa: bool,
-        B: torch.Tensor,
+        B: List[Any],
         transb: bool,
         D: Optional[List[torch.Tensor]],
         D_type: DType,
@@ -791,8 +791,8 @@ class TEFLBackendBase(ABC):
     def fp8_transpose(
         self,
         input: torch.Tensor,
-        otype: DType,
-        output: Optional[torch.Tensor],
+        dtype: DType,
+        out: Optional[torch.Tensor],
     ) -> torch.Tensor:
         raise NotImplementedError
     def swap_first_dims(

--- a/transformer_engine/plugin/core/ops.py
+++ b/transformer_engine/plugin/core/ops.py
@@ -11,6 +11,7 @@ import torch
 from .logger_manager import get_logger
 logger = get_logger()
 
+################### Enums ###################
 class DType(IntEnum):
     kByte = 0
     kInt16 = 1
@@ -141,936 +142,41 @@ class CommOverlapAlgo(IntEnum):
     ATOMIC_GEMM_RS_P2P = 7
     EXTERNAL_BULK_OVERLAP_AG = 8
 
+############ Class #################
+
 class FP8TensorMeta:
-    def __init__(self):
-        self.scale: Optional[torch.Tensor] = None
-        self.scale_inv: Optional[torch.Tensor] = None
-        self.amax_history: Optional[torch.Tensor] = None
-
-class CommGemmOverlapAlgoConfig:
-    def __init__(self, *args, **kwargs):
-        pass
-
-class FusedAdamCUDAKernel:
-    def __init__(self, *args, **kwargs):
-        raise NotImplementedError(
-            "FusedAdamCUDAKernel requires CUDA extensions. "
-            "Not supported in FL mode."
-        )
-
-class FusedSGDCUDAKernel:
-    def __init__(self, *args, **kwargs):
-        raise NotImplementedError(
-            "FusedSGDCUDAKernel requires CUDA extensions. "
-            "Not supported in FL mode."
-        )
+    """
+    FP8TensorMeta wrapper that routes to the appropriate backend implementation.
+    """
+    def __new__(cls, *args, **kwargs):
+        from .manager import get_default_manager
+        return get_default_manager().call("create_fp8_tensor_meta", *args, **kwargs)
 
 class CommOverlapHelper:
-    def __init__(self, world_group=None, intra_node_group=None):
-        self.world_group = world_group
-        self.intra_node_group = intra_node_group
+    """
+    CommOverlapHelper wrapper that routes to the appropriate backend implementation.
+    """
+    def __new__(cls, *args, **kwargs):
+        from .manager import get_default_manager
+        return get_default_manager().call("create_comm_overlap_helper", *args, **kwargs)
 
 class CommOverlap:
-    def __init__(self, *args, **kwargs):
-        raise NotImplementedError(
-            "CommOverlap should be created via backend.create_comm_overlap(). "
-            "Direct instantiation is not supported in FL mode."
-        )
+    """
+    CommOverlap wrapper that routes to the appropriate backend implementation.
+    """
+    def __new__(cls, *args, **kwargs):
+        from .manager import get_default_manager
+        return get_default_manager().call("create_comm_overlap", *args, **kwargs)
 
 class CommOverlapP2P:
-    def __init__(self, *args, **kwargs):
-        raise NotImplementedError(
-            "CommOverlapP2P should be created via backend.create_comm_overlap_p2p(). "
-            "Direct instantiation is not supported in FL mode."
-        )
-
-class TEFLBackendBase(ABC):
-    @abstractmethod
-    def is_available(self) -> bool:
-        raise NotImplementedError
-
-    def get_flash_attention_class(self) -> Type["FlashAttentionBase"]:
-        raise NotImplementedError
-
-    def get_attention_backend(self, attention_params=None):
-        raise NotImplementedError
-
-    def quantize(
-        self,
-        tensor: torch.Tensor,
-        quantizer: Any,
-        output: Optional[torch.Tensor] = None,
-        noop: Optional[torch.Tensor] = None,
-    ) -> Any:
-        raise NotImplementedError
-
-    def dequantize(
-        self,
-        input: torch.Tensor,
-        otype: torch.dtype,
-    ) -> torch.Tensor:
-        raise NotImplementedError
-
-    def bgrad_quantize(
-        self,
-        input: torch.Tensor,
-        quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
-        raise NotImplementedError
-
-    def generic_gemm(
-        self,
-        A: torch.Tensor,
-        transA: bool,
-        B: torch.Tensor,
-        transB: bool,
-        D: torch.Tensor,
-        quantizer: Any,
-        output_dtype: torch.dtype,
-        bias: Optional[torch.Tensor],
-        bias_type: Any,
-        gelu: bool,
-        gelu_in: Optional[torch.Tensor],
-        grad: bool,
-        workspace: torch.Tensor,
-        workspace_size: int,
-        accumulate: bool,
-        use_split_accumulator: bool,
-        comm_overlap: Optional[Any] = None,
-        comm_type: Optional[Any] = None,
-        extra_output: Optional[torch.Tensor] = None,
-        bulk_overlap: bool = False,
-        alpha: float = 1.0,
-        beta: Optional[float] = None,
-    ) -> Any:
-        raise NotImplementedError
-
-    def te_general_grouped_gemm(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def gelu(
-        self,
-        input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def geglu(
-        self,
-        input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def qgelu(
-        self,
-        input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def qgeglu(
-        self,
-        input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def relu(
-        self,
-        input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def reglu(
-        self,
-        input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def srelu(
-        self,
-        input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def sreglu(
-        self,
-        input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def silu(
-        self,
-        input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def swiglu(
-        self,
-        input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def clamped_swiglu(
-        self,
-        input: torch.Tensor,
-        quantizer: Any,
-        limit: float = 7.0,
-        alpha: float = 1.702,
-    ) -> Any:
-        raise NotImplementedError
-
-    def dgelu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def dgeglu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def dqgelu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def dqgeglu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def drelu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def dreglu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def dsrelu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def dsreglu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def dsilu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def dswiglu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def clamped_dswiglu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-        limit: float = 7.0,
-        alpha: float = 1.702,
-    ) -> Any:
-        raise NotImplementedError
-
-    def dbias_dgelu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
-        raise NotImplementedError
-
-    def dbias_dsilu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
-        raise NotImplementedError
-
-    def dbias_drelu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
-        raise NotImplementedError
-
-    def dbias_dqgelu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
-        raise NotImplementedError
-
-    def dbias_dsrelu(
-        self,
-        grad: torch.Tensor,
-        fwd_input: torch.Tensor,
-        quantizer: Any,
-    ) -> Tuple[torch.Tensor, Any]:
-        raise NotImplementedError
-
-    def layernorm_fwd(
-        self,
-        input: torch.Tensor,
-        weight: torch.Tensor,
-        bias: Optional[torch.Tensor],
-        eps: float,
-        ln_out: Optional[torch.Tensor],
-        quantizer: Any,
-        otype: torch.dtype,
-        sm_margin: int,
-        zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        raise NotImplementedError
-
-    def layernorm_bwd(
-        self,
-        dy: torch.Tensor,
-        x: torch.Tensor,
-        mu: torch.Tensor,
-        rsigma: torch.Tensor,
-        gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        raise NotImplementedError
-
-    def rmsnorm_fwd(
-        self,
-        input: torch.Tensor,
-        weight: torch.Tensor,
-        eps: float,
-        ln_out: Optional[torch.Tensor],
-        quantizer: Any,
-        otype: torch.dtype,
-        sm_margin: int,
-        zero_centered_gamma: bool,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
-        raise NotImplementedError
-
-    def rmsnorm_bwd(
-        self,
-        dy: torch.Tensor,
-        x: torch.Tensor,
-        rsigma: torch.Tensor,
-        gamma: torch.Tensor,
-        sm_margin: int = 0,
-        zero_centered_gamma: bool = False,
-        eps: float = 1e-5,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        raise NotImplementedError
-
-    def rmsnorm_bwd_add(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def multi_tensor_quantize(
-        self,
-        tensor_list: List[torch.Tensor],
-        quantizer_list: List[Any],
-    ) -> List[Any]:
-        raise NotImplementedError
-
-    def split_quantize(
-        self,
-        tensor: torch.Tensor,
-        split_sections: List[int],
-        quantizer_list: List[Any],
-    ) -> List[Any]:
-        raise NotImplementedError
-
-    def moe_permute_fwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError
-
-    def moe_permute_bwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError
-
-    def moe_unpermute_fwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError
-
-    def moe_unpermute_bwd(self, *args, **kwargs) -> Any:
-        raise NotImplementedError
-
-    def scaled_softmax_forward(
-        self,
-        input: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        raise NotImplementedError
-
-    def scaled_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        raise NotImplementedError
-
-    def scaled_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        mask: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        raise NotImplementedError
-
-    def scaled_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        raise NotImplementedError
-
-    def scaled_upper_triang_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        raise NotImplementedError
-
-    def scaled_upper_triang_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        raise NotImplementedError
-
-    def scaled_aligned_causal_masked_softmax_forward(
-        self,
-        input: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        raise NotImplementedError
-
-    def scaled_aligned_causal_masked_softmax_backward(
-        self,
-        output_grad: torch.Tensor,
-        softmax_output: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
-        raise NotImplementedError
-
-    def get_fused_attn_backend(
-        self,
-        *args,
-        **kwargs,
-    ) -> int:
-        raise NotImplementedError
-
-    def fused_attn_fwd(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def fused_attn_bwd(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def fa_prepare_fwd(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def fa_prepare_bwd(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def copy_to_kv_cache(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def convert_thd_to_bshd(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def convert_bshd_to_thd(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def fused_rope_forward(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def fused_rope_backward(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def fused_qkv_rope_forward(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def fused_qkv_rope_backward(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def fused_topk_with_score_function_fwd(
-        self,
-        logits: torch.Tensor,
-        topk: int,
-        use_pre_softmax: bool,
-        num_groups: int,
-        group_topk: int,
-        scaling_factor: float,
-        score_function: Any,
-        expert_bias: Optional[torch.Tensor],
-    ) -> Any:
-        raise NotImplementedError
-
-    def fused_topk_with_score_function_bwd(
-        self,
-        num_tokens: int,
-        num_experts: int,
-        routing_map: torch.Tensor,
-        intermediate_output: torch.Tensor,
-        grad_probs: torch.Tensor,
-        topk: int,
-        use_pre_softmax: bool,
-        scaling_factor: float,
-        score_function: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def fused_score_for_moe_aux_loss_fwd(
-        self,
-        logits: torch.Tensor,
-        topk: int,
-        score_function: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def fused_score_for_moe_aux_loss_bwd(
-        self,
-        num_tokens: int,
-        num_experts: int,
-        intermediate_output: torch.Tensor,
-        grad_scores: torch.Tensor,
-        topk: int,
-        score_function: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def fused_moe_aux_loss_fwd(
-        self,
-        probs: torch.Tensor,
-        tokens_per_expert: torch.Tensor,
-        total_num_tokens: int,
-        num_experts: int,
-        num_rows: int,
-        num_cols: int,
-        topk: int,
-        coeff: float,
-    ) -> Any:
-        raise NotImplementedError
-
-    def fused_moe_aux_loss_bwd(
-        self,
-        Const_buf: torch.Tensor,
-        tokens_per_expert: torch.Tensor,
-        num_rows: int,
-        num_cols: int,
-        grad_aux_loss: torch.Tensor,
-    ) -> Any:
-        raise NotImplementedError
-
-    def dropout_fwd(
-        self,
-        input: torch.Tensor,
-        dropout_probability: float,
-        out: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        raise NotImplementedError
-
-    def dropout_bwd(
-        self,
-        grad_output: torch.Tensor,
-        mask: torch.Tensor,
-        dropout_probability: float,
-        grad_input: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        raise NotImplementedError
-
-    def fp8_transpose(
-        self,
-        input: torch.Tensor,
-        dtype: Any,
-        *,
-        out: torch.Tensor,
-    ) -> None:
-        raise NotImplementedError
-
-    def swap_first_dims(
-        self,
-        tensor: torch.Tensor,
-        *,
-        out: torch.Tensor,
-    ) -> None:
-        raise NotImplementedError
-
-    def compute_amax(
-        self,
-        input: torch.Tensor,
-        amax: torch.Tensor,
-    ) -> None:
-        raise NotImplementedError
-
-    def fused_amax_and_scale_update_after_reduction(
-        self,
-        *args,
-        **kwargs,
-    ) -> None:
-        raise NotImplementedError
-
-    def fp8_block_scaling_compute_partial_amax(
-        self,
-        tensor: torch.Tensor,
-        amax: torch.Tensor,
-        h: int,
-        w: int,
-        start_offset: int,
-        block_len: int,
-    ) -> None:
-        raise NotImplementedError
-
-    def fp8_block_scaling_partial_cast(
-        self,
-        inp: torch.Tensor,
-        out: torch.Tensor,
-        scale: torch.Tensor,
-        h: int,
-        w: int,
-        start_offset: int,
-        block_len: int,
-        out_dtype: Any,
-    ) -> None:
-        raise NotImplementedError
-
-    def fused_multi_row_padding(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def fused_multi_row_unpadding(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def get_cublasLt_version(self) -> int:
-        raise NotImplementedError
-
-    def get_cudnn_version(self) -> int:
-        raise NotImplementedError
-
-    def get_num_cublas_streams(self) -> int:
-        raise NotImplementedError
-
-    def thd_read_half_tensor(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def thd_second_half_lse_correction(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def thd_read_second_half_lse(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def thd_out_correction(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def thd_grad_correction(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def thd_get_partitioned_indices(
-        self,
-        *args,
-        **kwargs,
-    ) -> Any:
-        raise NotImplementedError
-
-    def init_nvshmem_backend(
-        self,
-        *args,
-        **kwargs,
-    ) -> None:
-        raise NotImplementedError
-
-    def create_nvshmem_tensor(
-        self,
-        *args,
-        **kwargs,
-    ) -> torch.Tensor:
-        raise NotImplementedError
-
-    def nvshmem_send_on_current_stream(
-        self,
-        *args,
-        **kwargs,
-    ) -> None:
-        raise NotImplementedError
-
-    def nvshmem_wait_on_current_stream(
-        self,
-        *args,
-        **kwargs,
-    ) -> None:
-        raise NotImplementedError
-
-    def nvshmem_finalize(self) -> None:
-        raise NotImplementedError
-
-    def multi_tensor_scale(
-        self,
-        chunk_size: int,
-        noop_flag: torch.Tensor,
-        tensor_lists: List[List[torch.Tensor]],
-        scale: float,
-    ) -> None:
-        raise NotImplementedError
-
-    def multi_tensor_l2norm(
-        self,
-        chunk_size: int,
-        noop_flag: torch.Tensor,
-        tensor_lists: List[List[torch.Tensor]],
-        per_tensor: bool = False,
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
-        raise NotImplementedError
-
-    def multi_tensor_unscale_l2norm(
-        self,
-        chunk_size: int,
-        noop_flag: torch.Tensor,
-        tensor_lists: List[List[torch.Tensor]],
-        scale: torch.Tensor,
-        per_tensor: bool = False,
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
-        raise NotImplementedError
-
-    def multi_tensor_adam(
-        self,
-        chunk_size: int = None,
-        noop_flag: torch.Tensor = None,
-        tensor_lists: List[List[torch.Tensor]] = None,
-        lr: float = None,
-        beta1: float = None,
-        beta2: float = None,
-        eps: float = None,
-        step: int = None,
-        mode: int = None,
-        bias_correction: int = None,
-        weight_decay: float = None,
-    ):
-        raise NotImplementedError
-
-    def multi_tensor_adam_param_remainder(
-        self,
-        *args,
-        **kwargs,
-    ) -> None:
-        raise NotImplementedError
-
-    def multi_tensor_adam_fp8(
-        self,
-        *args,
-        **kwargs,
-    ) -> None:
-        raise NotImplementedError
-
-    def multi_tensor_adam_capturable(
-        self,
-        *args,
-        **kwargs,
-    ) -> None:
-        raise NotImplementedError
-
-    def multi_tensor_adam_capturable_master(
-        self,
-        *args,
-        **kwargs,
-    ) -> None:
-        raise NotImplementedError
-
-    def multi_tensor_sgd(
-        self,
-        *args,
-        **kwargs,
-    ) -> None:
-        raise NotImplementedError
-
-    def multi_tensor_compute_scale_and_scale_inv(
-        self,
-        *args,
-        **kwargs,
-    ) -> None:
-        raise NotImplementedError
-
-    def bulk_overlap_ag_with_external_gemm(
-        self,
-        allgather_communicator: Any,
-        send_stream: Any,
-        recv_stream: Any,
-    ) -> Any:
-        raise NotImplementedError
-
-    def create_fp8_tensor_meta(self) -> FP8TensorMeta:
-        raise NotImplementedError
-
-    def create_comm_overlap_helper(
-        self,
-        world_group: Optional[Any] = None,
-        intra_node_group: Optional[Any] = None,
-    ) -> Any:
-        raise NotImplementedError
-
-    def create_comm_overlap(
-        self,
-        buffer_shape: List[int],
-        buffer_dtype: torch.dtype,
-        helper: Any,
-        tp_size: int,
-        num_splits: int = 3,
-        num_max_streams: int = 3,
-        comm_cga_size: int = 2,
-        gemm_priority: int = 0,
-        comm_priority: int = 0,
-        num_comm_sm: int = 16,
-        set_sm_margin: bool = True,
-        atomic_gemm: bool = False,
-        rs_overlap_first_gemm: bool = False,
-    ) -> Any:
-        raise NotImplementedError
-
-    def create_comm_overlap_p2p(
-        self,
-        buffer_shape: List[int],
-        buffer_dtype: torch.dtype,
-        helper: Any,
-        tp_size: int,
-        comm_type: Any,
-        num_max_streams: int = 3,
-        comm_cga_size: int = 1,
-        gemm_priority: int = 0,
-        comm_priority: int = 0,
-        num_comm_sm: int = 1,
-        set_sm_margin: bool = False,
-        atomic_gemm: bool = False,
-        use_ce: bool = True,
-        aggregate: bool = False,
-    ) -> Any:
-        raise NotImplementedError
+    """
+    CommOverlapP2P wrapper that routes to the appropriate backend implementation.
+    """
+    def __new__(cls, *args, **kwargs):
+        from .manager import get_default_manager
+        return get_default_manager().call("create_comm_overlap_p2p", *args, **kwargs)
 
 class FlashAttentionBase(torch.nn.Module, ABC):
-
     def __init__(
         self,
         softmax_scale: float,
@@ -1246,7 +352,1064 @@ class FlashAttentionBase(torch.nn.Module, ABC):
     def backend_name(self) -> str:
         return self.__class__.__name__
 
+############ Base  ###################
+class TEFLBackendBase(ABC):
+    @abstractmethod
+    def is_available(self) -> bool:
+        raise NotImplementedError
 
+    def get_attention_backend(self, attention_params=None):
+        raise NotImplementedError
+
+##### transformer_engine/pytorch/csrc/extensions/pybind.cpp #####
+    def quantize(
+        self,
+        tensor: torch.Tensor,
+        quantizer: Any,
+        output: Optional[Any] = None,
+        noop: Optional[torch.Tensor] = None,
+    ) -> Any:
+        raise NotImplementedError
+
+    def dequantize(
+        self,
+        input: Any,
+        otype: DType,
+    ) -> Any:
+        raise NotImplementedError
+
+    def bgrad_quantize(
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+
+    def generic_gemm(
+        self,
+        A: Any,
+        transa: bool,
+        B: Any,
+        transb: bool,
+        D: Any,
+        quantizer: Any,
+        out_dtype: Optional[DType],
+        bias: Optional[torch.Tensor],
+        bias_type: DType,
+        gelu: bool,
+        gelu_in: Optional[torch.Tensor],
+        grad: bool,
+        workspace: torch.Tensor,
+        workspaceSize: int,
+        accumulate: bool,
+        use_split_accumulator: bool,
+        comm_overlap: Optional[Any] = None,
+        comm_type: Optional[CommOverlapType] = None,
+        extra_output: Optional[torch.Tensor] = None,
+        bulk_overlap: bool = False,
+        alpha: float = 1.0,
+        beta: Optional[float] = None,
+    ) -> List[Any]:
+        raise NotImplementedError
+
+    # GELU and variants #
+    def gelu(
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def geglu(
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def qgelu(
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def qgeglu(
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    # ReLU and variants #
+    def relu(
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def reglu(
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def srelu(
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def sreglu(
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    # SwiGLU and variants #
+    def silu(
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def swiglu(
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def clamped_swiglu(
+        self,
+        input: torch.Tensor,
+        quantizer: Any,
+        limit: float = 7.0,
+        alpha: float = 1.702,
+    ) -> Any:
+        raise NotImplementedError
+    # Backward of GELU and variants #
+    def dgelu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def dgeglu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def dqgelu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def dqgeglu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    # Backward of ReLU and variants #
+    def drelu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def dreglu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def dsrelu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def dsreglu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    # Backward of SiLU and variants #
+    def dsilu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def dswiglu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Any:
+        raise NotImplementedError
+    def clamped_dswiglu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+        limit: float = 7.0,
+        alpha: float = 1.702,
+    ) -> Any:
+        raise NotImplementedError
+    # DBias + DAct fusions #
+    def dbias_dgelu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Tuple[torch.Tensor, Any]:
+        raise NotImplementedError
+    def dbias_dsilu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Tuple[torch.Tensor, Any]:
+        raise NotImplementedError
+    def dbias_drelu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Tuple[torch.Tensor, Any]:
+        raise NotImplementedError
+    def dbias_dqgelu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Tuple[torch.Tensor, Any]:
+        raise NotImplementedError
+    def dbias_dsrelu(
+        self,
+        grad: torch.Tensor,
+        fwd_input: torch.Tensor,
+        quantizer: Any,
+    ) -> Tuple[torch.Tensor, Any]:
+        raise NotImplementedError
+    # Permutation functions                                                                                                                                                                                                                                                                                             
+    def moe_permute_fwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        indices: torch.Tensor,
+        num_out_tokens: int,
+        workspace: List[torch.Tensor],
+        max_expanded_token_num: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, List[torch.Tensor]]:
+        raise NotImplementedError
+    def moe_permute_bwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+        num_tokens: int,
+        topK: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def moe_unpermute_fwd(
+        self,
+        input: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+        num_tokens: int,
+        topK: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def moe_unpermute_bwd(
+        self,
+        input_bwd: torch.Tensor,
+        input_fwd: torch.Tensor,
+        dtype: DType,
+        row_id_map: torch.Tensor,
+        prob: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+    # Softmax functions
+    def scaled_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale: float,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def scaled_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def scaled_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        mask: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def scaled_masked_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def scaled_upper_triang_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def scaled_upper_triang_masked_softmax_backward(
+        self,
+        output_grads_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def scaled_aligned_causal_masked_softmax_forward(
+        self,
+        input: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def scaled_aligned_causal_masked_softmax_backward(
+        self,
+        output_grad_: torch.Tensor,
+        softmax_results_: torch.Tensor,
+        scale_factor: float,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    # Other granular functions
+    def layernorm_fwd(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor],
+        eps: float,
+        ln_out: Optional[torch.Tensor],
+        quantizer: Any,
+        otype: DType,
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+    def layernorm_bwd(
+        self,
+        dz: torch.Tensor,
+        x: torch.Tensor,
+        mu: torch.Tensor,
+        rsigma: torch.Tensor,
+        gamma: torch.Tensor,
+        sm_margin: int = 0,
+        zero_centered_gamma: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+    def rmsnorm_fwd(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        eps: float,
+        ln_out: Optional[torch.Tensor],
+        quantizer: Any,
+        otype: DType,
+        sm_margin: int,
+        zero_centered_gamma: bool,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+        raise NotImplementedError
+    def rmsnorm_bwd(
+        self,
+        dz: torch.Tensor,
+        x: torch.Tensor,
+        rsigma: torch.Tensor,
+        gamma: torch.Tensor,
+        sm_margin: int = 0,
+        zero_centered_gamma: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+    def rmsnorm_bwd_add(
+        self,
+        dz: torch.Tensor,
+        x: torch.Tensor,
+        add: torch.Tensor,
+        rsigma: torch.Tensor,
+        gamma: torch.Tensor,
+        sm_margin: int = 0,
+        zero_centered_gamma: bool = False,
+    ) -> Any:
+        raise NotImplementedError
+
+    def multi_tensor_quantize(
+        self,
+        tensor_list: List[torch.Tensor],
+        quantizer_list: List[Any],
+    ) -> List[Any]:
+        raise NotImplementedError
+    def split_quantize(
+        self,
+        tensor: torch.Tensor,
+        split_sections: List[int],
+        quantizer_list: List[Any],
+    ) -> List[Any]:
+        raise NotImplementedError
+    def te_general_grouped_gemm(
+        self,
+        A: torch.Tensor,
+        transa: bool,
+        B: torch.Tensor,
+        transb: bool,
+        D: Optional[List[torch.Tensor]],
+        D_type: DType,
+        m_splits: List[int],
+        bias: List[torch.Tensor],
+        bias_type: DType,
+        single_output: bool,
+        pre_gelu_out: List[torch.Tensor],
+        grad: bool,
+        workspace: List[torch.Tensor],
+        workspaceSizes: int,
+        accumulate: bool,
+        use_split_accumulator: bool,
+        math_sm_count: int,
+    ) -> Optional[List[torch.Tensor]]:
+        raise NotImplementedError
+    def fp8_transpose(
+        self,
+        input: torch.Tensor,
+        otype: DType,
+        output: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def swap_first_dims(
+        self,
+        tensor: torch.Tensor,
+        out: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def get_fused_attn_backend(
+        self,
+        is_training: bool,
+        q_dtype: DType,
+        kv_dtype: DType,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        p_dropout: float,
+        num_attn_heads: int,
+        num_gqa_groups: int,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        head_dim_qk: int,
+        head_dim_v: int,
+        window_size_left: int,
+        window_size_right: int,
+        return_max_logit: bool,
+    ) -> NVTE_Fused_Attn_Backend:
+        raise NotImplementedError
+
+    def compute_amax(
+        self,
+        input: torch.Tensor,
+        amax: torch.Tensor,
+    ) -> None:
+        raise NotImplementedError
+    def fused_amax_and_scale_update_after_reduction(
+        self,
+        amax_reduction_buffer: torch.Tensor,
+        amax_histories: List[torch.Tensor],
+        scales: List[torch.Tensor],
+        amax_compute_algo: str,
+        fp8_dtype: DType,
+        margin: float,
+    ) -> None:
+        raise NotImplementedError
+    def fp8_block_scaling_compute_partial_amax(
+        self,
+        tensor: torch.Tensor,
+        amax: torch.Tensor,
+        h: int,
+        w: int,
+        start_offset: int,
+        block_len: int,
+    ) -> None:
+        raise NotImplementedError
+    def fp8_block_scaling_partial_cast(
+        self,
+        inp: torch.Tensor,
+        out: torch.Tensor,
+        scale: torch.Tensor,
+        h: int,
+        w: int,
+        start_offset: int,
+        block_len: int,
+        out_dtype: DType,
+    ) -> None:
+        raise NotImplementedError
+    def fused_multi_row_padding(
+        self,
+        input: torch.Tensor,
+        output: torch.Tensor,
+        input_row_list: List[int],
+        padded_input_row_list: List[int],
+    ) -> None:
+        raise NotImplementedError
+    def fused_multi_row_unpadding(
+        self,
+        input: torch.Tensor,
+        output: torch.Tensor,
+        input_row_list: List[int],
+        unpadded_input_row_list: List[int],
+    ) -> None:
+        raise NotImplementedError
+
+    # attention kernels
+    def fa_prepare_fwd(
+        self,
+        qkvi: torch.Tensor,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def fa_prepare_bwd(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def fused_attn_fwd(
+        self,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        is_training: bool,
+        attn_scale: float,
+        p_dropout: float,
+        set_zero: bool,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        window_size: List[int],
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_kv: torch.Tensor,
+        Q: Any,
+        K: Any,
+        V: Any,
+        fake_dtype: torch.dtype,
+        cu_seqlens_q_padded: Optional[torch.Tensor],
+        cu_seqlens_kv_padded: Optional[torch.Tensor],
+        page_table_k: Optional[torch.Tensor],
+        page_table_v: Optional[torch.Tensor],
+        s_quantizer: Any,
+        o_quantizer: Any,
+        Bias: Optional[torch.Tensor],
+        SoftmaxOffset: Optional[torch.Tensor],
+        rng_gen: Optional[torch.Generator],
+        rng_elts_per_thread: int,
+        return_max_logit: bool,
+    ) -> List[Any]:
+        raise NotImplementedError
+    def fused_attn_bwd(
+        self,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        attn_scale: float,
+        p_dropout: float,
+        set_zero: bool,
+        qkv_layout: NVTE_QKV_Layout,
+        bias_type: NVTE_Bias_Type,
+        attn_mask_type: NVTE_Mask_Type,
+        softmax_type: NVTE_Softmax_Type,
+        window_size: List[int],
+        deterministic: bool,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_kv: torch.Tensor,
+        Q: Any,
+        K: Any,
+        V: Any,
+        O: Any,
+        dO: Any,
+        fake_dtype: torch.dtype,
+        dqkv_type: DType,
+        Aux_CTX_Tensors: List[torch.Tensor],
+        cu_seqlens_q_padded: Optional[torch.Tensor],
+        cu_seqlens_kv_padded: Optional[torch.Tensor],
+        s_quantizer: Any,
+        dp_quantizer: Any,
+        dqkv_quantizer: Any,
+    ) -> List[Any]:
+        raise NotImplementedError
+    def copy_to_kv_cache(
+        self,
+        new_k: torch.Tensor,
+        new_v: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        page_table: torch.Tensor,
+        cu_new_lens: torch.Tensor,
+        cu_cached_lens: torch.Tensor,
+        qkv_format: NVTE_QKV_Format,
+        b: int,
+        max_ctx_len: int,
+        max_seq_len: int,
+        max_pages_per_seq: int,
+        is_non_paged: bool,
+    ) -> None:
+        raise NotImplementedError
+    def convert_thd_to_bshd(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        b: int,
+        max_seq_len: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def convert_bshd_to_thd(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        t: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    # fused apply rope
+    def fused_rope_forward(
+        self,
+        input: torch.Tensor,
+        freqs: torch.Tensor,
+        start_positions: Optional[torch.Tensor],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cu_seqlens: Optional[torch.Tensor],
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def fused_rope_backward(
+        self,
+        output_grads: torch.Tensor,
+        freqs: torch.Tensor,
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cu_seqlens: Optional[torch.Tensor],
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def fused_qkv_rope_forward(
+        self,
+        qkv_input: torch.Tensor,
+        q_freqs: torch.Tensor,
+        k_freqs: torch.Tensor,
+        start_positions: Optional[torch.Tensor],
+        qkv_split_arg_list: List[int],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cp_size: int,
+        cp_rank: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+    def fused_qkv_rope_backward(
+        self,
+        q_grad_out: torch.Tensor,
+        k_grad_out: torch.Tensor,
+        v_grad_out: torch.Tensor,
+        q_freqs: torch.Tensor,
+        k_freqs: torch.Tensor,
+        qkv_split_arg_list: List[int],
+        qkv_format: NVTE_QKV_Format,
+        interleaved: bool,
+        cp_size: int,
+        cp_rank: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    # fused router
+    def fused_topk_with_score_function_fwd(
+        self,
+        logits: torch.Tensor,
+        topk: int,
+        use_pre_softmax: bool,
+        num_groups: Optional[int],
+        group_topk: Optional[int],
+        scaling_factor: Optional[float],
+        score_function: str,
+        expert_bias: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+    def fused_topk_with_score_function_bwd(
+        self,
+        num_tokens: int,
+        num_experts: int,
+        routing_map: torch.Tensor,
+        intermediate_output: torch.Tensor,
+        grad_probs: torch.Tensor,
+        topk: int,
+        use_pre_softmax: bool,
+        scaling_factor: Optional[float],
+        score_function: str,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def fused_score_for_moe_aux_loss_fwd(
+        self,
+        logits: torch.Tensor,
+        topk: int,
+        score_function: str,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+    def fused_score_for_moe_aux_loss_bwd(
+        self,
+        num_tokens: int,
+        num_experts: int,
+        intermediate_output: torch.Tensor,
+        grad_scores: torch.Tensor,
+        topk: int,
+        score_function: str,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def fused_moe_aux_loss_fwd(
+        self,
+        probs: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        total_num_tokens: int,
+        num_experts: int,
+        num_rows: int,
+        num_cols: int,
+        topk: int,
+        coeff: float,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+    def fused_moe_aux_loss_bwd(
+        self,
+        Const_buf: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        num_rows: int,
+        num_cols: int,
+        grad_aux_loss: torch.Tensor,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    # Dropout
+    def dropout_fwd(
+        self,
+        input: torch.Tensor,
+        dropout_probability: float,
+        out: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+    def dropout_bwd(
+        self,
+        grad_output: torch.Tensor,
+        mask: torch.Tensor,
+        dropout_probability: float,
+        grad_input: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    # Misc
+    def get_cublasLt_version(self) -> int:
+        raise NotImplementedError
+    def get_cudnn_version(self) -> int:
+        raise NotImplementedError
+    def get_num_cublas_streams(self) -> int:
+        raise NotImplementedError
+
+    # Support THD format for Context Parallel
+    def thd_read_half_tensor(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        half_idx: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def thd_second_half_lse_correction(
+        self,
+        lse: torch.Tensor,
+        lse_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        lse_packed: bool,
+    ) -> None:
+        raise NotImplementedError
+    def thd_read_second_half_lse(
+        self,
+        lse: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        lse_packed: bool,
+        second_half_lse_seqlen: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def thd_out_correction(
+        self,
+        out: torch.Tensor,
+        out_per_step: torch.Tensor,
+        lse: torch.Tensor,
+        lse_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        only_second_half: bool,
+        lse_packed: bool,
+    ) -> None:
+        raise NotImplementedError
+    def thd_grad_correction(
+        self,
+        grad: torch.Tensor,
+        grad_per_step: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        first_half: str,
+        second_half: str,
+    ) -> None:
+        raise NotImplementedError
+    def thd_get_partitioned_indices(
+        self,
+        cu_seqlens: torch.Tensor,
+        total_tokens: int,
+        world_size: int,
+        rank: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    # nvshmem functions
+    def init_nvshmem_backend(
+        self,
+        process_group: Any,
+    ) -> None:
+        raise NotImplementedError
+    def create_nvshmem_tensor(
+        self,
+        shape: List[int],
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+    def nvshmem_send_on_current_stream(
+        self,
+        src: torch.Tensor,
+        dst: torch.Tensor,
+        peer: int,
+        signal: torch.Tensor,
+    ) -> None:
+        raise NotImplementedError
+    def nvshmem_wait_on_current_stream(
+        self,
+        signal: torch.Tensor,
+        wait_kind: str,
+    ) -> None:
+        raise NotImplementedError
+    def nvshmem_finalize(self) -> None:
+        raise NotImplementedError
+
+    # multi-tensor functions
+    def multi_tensor_scale(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        scale: float,
+    ) -> None:
+        raise NotImplementedError
+    def multi_tensor_l2norm(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        per_tensor: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+    def multi_tensor_unscale_l2norm(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        inv_scale: torch.Tensor,
+        per_tensor: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+    def multi_tensor_adam(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
+        raise NotImplementedError
+    def multi_tensor_adam_param_remainder(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+    ) -> None:
+        raise NotImplementedError
+    def multi_tensor_adam_fp8(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: float,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: int,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        fp8_dtype: DType,
+    ) -> None:
+        raise NotImplementedError
+    def multi_tensor_adam_capturable(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: torch.Tensor,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: torch.Tensor,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        inv_scale: torch.Tensor,
+    ) -> None:
+        raise NotImplementedError
+    def multi_tensor_adam_capturable_master(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        lr: torch.Tensor,
+        beta1: float,
+        beta2: float,
+        epsilon: float,
+        step: torch.Tensor,
+        mode: int,
+        bias_correction: int,
+        weight_decay: float,
+        inv_scale: torch.Tensor,
+    ) -> None:
+        raise NotImplementedError
+    def multi_tensor_sgd(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        wd: float,
+        momentum: float,
+        dampening: float,
+        lr: float,
+        nesterov: bool,
+        first_run: bool,
+        wd_after_momentum: bool,
+        scale: float,
+    ) -> None:
+        raise NotImplementedError
+    def multi_tensor_compute_scale_and_scale_inv(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        max_fp8: float,
+        force_pow_2_scales: bool,
+        epsilon: float,
+    ) -> None:
+        raise NotImplementedError
+
+    # Comm+GEMM Overlap
+    def bulk_overlap_ag_with_external_gemm(
+        self,
+        allgather_communicator: CommOverlap,
+        send_stream: Any,
+        recv_stream: Any,
+    ) -> Any:
+        raise NotImplementedError
+
+############## class func #################################
+    def create_fp8_tensor_meta(self) -> FP8TensorMeta:
+        """Create FP8TensorMeta instance."""
+        raise NotImplementedError
+    def create_comm_overlap_helper(
+        self,
+        world_group: Optional[Any] = None,
+        intra_node_group: Optional[Any] = None,
+    ) -> "CommOverlapHelper":
+        """
+        Internal method to create CommOverlapHelper.
+        Users should use CommOverlapHelper(...) directly.
+        """
+        raise NotImplementedError
+    def create_comm_overlap(
+        self,
+        buffer_shape: List[int],
+        buffer_dtype: torch.dtype,
+        helper: Any,
+        tp_size: int,
+        num_splits: int = 3,
+        num_max_streams: int = 3,
+        comm_cga_size: int = 2,
+        gemm_priority: int = 0,
+        comm_priority: int = 0,
+        num_comm_sm: int = 16,
+        set_sm_margin: bool = True,
+        atomic_gemm: bool = False,
+        rs_overlap_first_gemm: bool = False,
+    ) -> "CommOverlap":
+        """
+        Internal method to create CommOverlap.
+        Users should use CommOverlap(...) directly.
+        """
+        raise NotImplementedError
+    def create_comm_overlap_p2p(
+        self,
+        buffer_shape: List[int],
+        buffer_dtype: torch.dtype,
+        helper: Any,
+        tp_size: int,
+        comm_type: Any,
+        num_max_streams: int = 3,
+        comm_cga_size: int = 1,
+        gemm_priority: int = 0,
+        comm_priority: int = 0,
+        num_comm_sm: int = 1,
+        set_sm_margin: bool = False,
+        atomic_gemm: bool = False,
+        use_ce: bool = True,
+        aggregate: bool = False,
+    ) -> "CommOverlapP2P":
+        """
+        Internal method to create CommOverlapP2P.
+        Users should use CommOverlapP2P(...) directly.
+        """
+        raise NotImplementedError
+    def get_flash_attention_class(self) -> Type["FlashAttentionBase"]:
+        raise NotImplementedError
+
+############ Wapper  #################
 class TEFLModule:
     def __init__(self, manager=None):
         """
@@ -1259,12 +1422,11 @@ class TEFLModule:
         # Import here to avoid circular dependency
         from .manager import get_default_manager
         self._manager = manager if manager is not None else get_default_manager()
-
+        # emum
         self.DType = DType
         self.Float8BlockScaleTensorFormat = Float8BlockScaleTensorFormat
         self.FP8FwdTensors = FP8FwdTensors
         self.FP8BwdTensors = FP8BwdTensors
-        self.FP8TensorMeta = FP8TensorMeta
         self.NVTE_Activation_Type = NVTE_Activation_Type
         self.NVTE_Bias_Type = NVTE_Bias_Type
         self.NVTE_Mask_Type = NVTE_Mask_Type
@@ -1275,14 +1437,11 @@ class TEFLModule:
         self.CommOverlapType = CommOverlapType
         self.CommOverlapAlgo = CommOverlapAlgo
         self.CommGemmOverlapRole = CommGemmOverlapRole
-
+        # class
+        self.FP8TensorMeta = FP8TensorMeta
         self.CommOverlapHelper = CommOverlapHelper
         self.CommOverlap = CommOverlap
         self.CommOverlapP2P = CommOverlapP2P
-        self.CommGemmOverlapAlgoConfig = CommGemmOverlapAlgoConfig
-
-        self.FusedAdamCUDAKernel = FusedAdamCUDAKernel
-        self.FusedSGDCUDAKernel = FusedSGDCUDAKernel
 
     def __getattr__(self, name: str) -> Any:
         """
@@ -1316,8 +1475,7 @@ class TEFLModule:
             'FP8TensorMeta', 'NVTE_Activation_Type', 'NVTE_Bias_Type', 'NVTE_Mask_Type',
             'NVTE_Softmax_Type', 'NVTE_Fused_Attn_Backend', 'NVTE_QKV_Format', 'NVTE_QKV_Layout',
             'CommOverlapType', 'CommOverlapAlgo', 'CommGemmOverlapRole',
-            'CommOverlapHelper', 'CommOverlap', 'CommOverlapP2P', 'CommGemmOverlapAlgoConfig',
-            'FusedAdamCUDAKernel', 'FusedSGDCUDAKernel'
+            'CommOverlapHelper', 'CommOverlap', 'CommOverlapP2P', 
         ]
 
         # Add operator names from OpManager's registry

--- a/transformer_engine/plugin/tests/test_normalization.py
+++ b/transformer_engine/plugin/tests/test_normalization.py
@@ -13,6 +13,7 @@ from transformer_engine.plugin.test_utils import (
     TestCase,
     generate_random_tensor,
 )
+from transformer_engine.plugin.core.ops import DType
 
 
 class NormalizationTests(TestCase):
@@ -57,7 +58,7 @@ class NormalizationTests(TestCase):
             try:
                 output, mean, rsigma = backend.layernorm_fwd(
                     x, weight, bias, self.eps,
-                    None, None, torch.float32, 0, False
+                    None, None, DType.kFloat32, 0, False
                 )
                 self.assert_close(
                     output, ref_output, rtol=1e-5, atol=1e-7,
@@ -143,7 +144,7 @@ class NormalizationTests(TestCase):
             try:
                 output, _, rsigma = backend.rmsnorm_fwd(
                     x, weight, self.eps,
-                    None, None, torch.float32, 0, False
+                    None, None, DType.kFloat32, 0, False
                 )
                 self.assert_close(
                     output, ref_output, rtol=1e-5, atol=1e-7,
@@ -185,7 +186,7 @@ class NormalizationTests(TestCase):
 
                 grad_x, grad_weight = backend.rmsnorm_bwd(
                     grad_output, x_copy, rsigma.detach(),
-                    weight_copy, 0, False, self.eps
+                    weight_copy, 0, False
                 )
 
                 self.assert_close(

--- a/transformer_engine/plugin/tests/test_operations.py
+++ b/transformer_engine/plugin/tests/test_operations.py
@@ -13,6 +13,7 @@ from transformer_engine.plugin.test_utils import (
     TestCase,
     generate_random_tensor,
 )
+from transformer_engine.plugin.core.ops import DType
 
 
 class OperationsTests(TestCase):
@@ -39,7 +40,7 @@ class OperationsTests(TestCase):
 
                 output, _, _, _ = backend.generic_gemm(
                     A, False, B, False, D,
-                    None, torch.float32, None, None,
+                    None, DType.kFloat32, None, DType.kFloat32,
                     False, None, False,
                     workspace, 1024, False, False
                 )
@@ -71,7 +72,7 @@ class OperationsTests(TestCase):
 
                 output, _, _, _ = backend.generic_gemm(
                     A, True, B, False, D,
-                    None, torch.float32, None, None,
+                    None, DType.kFloat32, None, DType.kFloat32,
                     False, None, False,
                     workspace, 1024, False, False
                 )
@@ -103,7 +104,7 @@ class OperationsTests(TestCase):
 
                 output, _, _, _ = backend.generic_gemm(
                     B_mat, False, A, False, D,
-                    None, torch.float32, None, None,
+                    None, DType.kFloat32, None, DType.kFloat32,
                     False, None, False,
                     workspace, 1024, False, False
                 )
@@ -181,7 +182,7 @@ class OperationsTests(TestCase):
         for backend_name in self.backends:
             backend = get_backend(backend_name)
             try:
-                output, mask = backend.dropout_fwd(x, dropout_prob)
+                output, mask = backend.dropout_fwd(x, dropout_prob, None)
 
                 num_nonzero = (output != 0).sum().item()
                 total_elements = output.numel()
@@ -206,7 +207,7 @@ class OperationsTests(TestCase):
                     )
 
                 grad_output = generate_random_tensor(shape, dtype=torch.bfloat16, device=self.device)
-                grad_input = backend.dropout_bwd(grad_output, mask, dropout_prob)
+                grad_input = backend.dropout_bwd(grad_output, mask, dropout_prob, None)
 
                 grad_nonzero_mask = (grad_input != 0)
                 output_nonzero_mask = (output != 0)

--- a/transformer_engine/plugin/tests/test_optimizer.py
+++ b/transformer_engine/plugin/tests/test_optimizer.py
@@ -201,7 +201,7 @@ class OptimizerTests(TestCase):
                     lr=lr,
                     beta1=beta1,
                     beta2=beta2,
-                    eps=eps,
+                    epsilon=eps,
                     step=step,
                     mode=1,  # AdamW mode
                     bias_correction=1,
@@ -258,7 +258,7 @@ class OptimizerTests(TestCase):
                     chunk_size=2048,
                     noop_flag=noop_flag,
                     tensor_lists=[tensors],
-                    scale=inv_scale,
+                    inv_scale=inv_scale,
                     per_tensor=False
                 )
 

--- a/transformer_engine/plugin/tests/test_optimizer.py
+++ b/transformer_engine/plugin/tests/test_optimizer.py
@@ -222,6 +222,155 @@ class OptimizerTests(TestCase):
                 self.failed += 1
                 print(f"    ✗ {backend_name}: {e}")
 
+    def _fp32_to_param_remainder(self, fp32_tensor):
+        """Split FP32 tensor into int16 param (high 16 bits) + int16 remainder (low 16 bits).
+
+        Matches the CUDA split convention:
+        1. Extract high 16 bits as param, low 16 bits as remainder.
+        2. If remainder < 0, increment param (round up).
+        """
+        int32 = fp32_tensor.view(torch.int32)
+        rem = (int32 & 0xFFFF).to(torch.int16)
+        high = ((int32 >> 16) & 0xFFFF).to(torch.int16)
+        high = torch.where(rem < 0, high + 1, high)
+        # param is stored as bf16 (same bits as high int16)
+        param = high.view(torch.bfloat16)
+        return param, rem
+
+    def _param_remainder_to_fp32(self, param, remainder):
+        """Reconstruct FP32 from int16 param (high bits) + int16 remainder (low bits).
+
+        Matches the CUDA reconstruct convention:
+        1. If remainder < 0, decrement param (undo rounding).
+        2. Combine high and low 16 bits into FP32.
+        """
+        local_p = param.view(torch.int16).clone()
+        local_rem = remainder.clone()
+        local_p = torch.where(local_rem < 0, local_p - 1, local_p)
+        high = local_p.to(torch.int32) << 16
+        low = local_rem.to(torch.int32) & 0xFFFF
+        return (high | low).view(torch.float32)
+
+    def _reference_adam_param_remainder(
+        self, grads, params, exp_avgs, exp_avg_sqs, param_remainders,
+        lr, beta1, beta2, epsilon, step, mode, bias_correction, weight_decay
+    ):
+        """Pure-PyTorch reference for multi_tensor_adam_param_remainder."""
+        bc1 = 1 - beta1 ** step if bias_correction else 1.0
+        bc2 = 1 - beta2 ** step if bias_correction else 1.0
+        is_adamw = (mode == 1)
+
+        for g, p, m, v, p_rem in zip(
+            grads, params, exp_avgs, exp_avg_sqs, param_remainders
+        ):
+            g_float = g.float()
+            param_master = self._param_remainder_to_fp32(p, p_rem)
+
+            if not is_adamw and weight_decay != 0:
+                g_float = g_float + weight_decay * param_master
+
+            m.mul_(beta1).add_(g_float, alpha=1 - beta1)
+            v.mul_(beta2).addcmul_(g_float, g_float, value=1 - beta2)
+
+            m_corr = m / bc1
+            v_corr = v / bc2
+            denom = torch.sqrt(v_corr) + epsilon
+            update = m_corr / denom
+
+            if is_adamw and weight_decay != 0:
+                update = update + weight_decay * param_master
+
+            param_master = param_master - lr * update
+
+            new_p, new_rem = self._fp32_to_param_remainder(param_master)
+            p.view(torch.int16).copy_(new_p.view(torch.int16))
+            p_rem.copy_(new_rem)
+
+    def test_multi_tensor_adam_param_remainder(self, num_tensors=3, shape=(32, 64)):
+        print(f"\n  Testing multi_tensor_adam_param_remainder with {num_tensors} tensors of shape {shape}")
+
+        lr = 0.001
+        beta1 = 0.9
+        beta2 = 0.999
+        eps = 1e-8
+        step = 1
+        weight_decay = 0.01
+        mode = 1  # AdamW
+
+        for backend_name in self.backends:
+            backend = get_backend(backend_name)
+            try:
+                # Create FP32 master weights, then split into param + remainder
+                master_weights = [generate_random_tensor(shape, dtype=torch.float32, device=self.device)
+                                  for _ in range(num_tensors)]
+                grads = [generate_random_tensor(shape, dtype=torch.bfloat16, device=self.device)
+                         for _ in range(num_tensors)]
+
+                params = []
+                remainders = []
+                for mw in master_weights:
+                    p, r = self._fp32_to_param_remainder(mw)
+                    params.append(p.clone())
+                    remainders.append(r.clone())
+
+                exp_avgs = [torch.zeros(shape, dtype=torch.float32, device=self.device)
+                            for _ in range(num_tensors)]
+                exp_avg_sqs = [torch.zeros(shape, dtype=torch.float32, device=self.device)
+                               for _ in range(num_tensors)]
+
+                # Clone for reference
+                ref_params = [p.clone() for p in params]
+                ref_remainders = [r.clone() for r in remainders]
+                ref_exp_avgs = [torch.zeros_like(m) for m in exp_avgs]
+                ref_exp_avg_sqs = [torch.zeros_like(v) for v in exp_avg_sqs]
+                ref_grads = [g.clone() for g in grads]
+
+                # Reference step
+                self._reference_adam_param_remainder(
+                    ref_grads, ref_params, ref_exp_avgs, ref_exp_avg_sqs, ref_remainders,
+                    lr, beta1, beta2, eps, step, mode, 1, weight_decay,
+                )
+
+                # Backend step
+                noop_flag = torch.tensor([0], dtype=torch.int32, device=self.device)
+                backend.multi_tensor_adam_param_remainder(
+                    chunk_size=2048,
+                    noop_flag=noop_flag,
+                    tensor_lists=[grads, params, exp_avgs, exp_avg_sqs, remainders],
+                    lr=lr,
+                    beta1=beta1,
+                    beta2=beta2,
+                    epsilon=eps,
+                    step=step,
+                    mode=mode,
+                    bias_correction=1,
+                    weight_decay=weight_decay,
+                )
+
+                # Compare reconstructed FP32 master weights
+                for i in range(num_tensors):
+                    out_fp32 = self._param_remainder_to_fp32(params[i], remainders[i])
+                    ref_fp32 = self._param_remainder_to_fp32(ref_params[i], ref_remainders[i])
+                    self.assert_close(
+                        out_fp32, ref_fp32, rtol=1e-5, atol=1e-7,
+                        msg=f"multi_tensor_adam_param_remainder param {i} mismatch for {backend_name}"
+                    )
+                    self.assert_close(
+                        exp_avgs[i], ref_exp_avgs[i], rtol=1e-5, atol=1e-7,
+                        msg=f"multi_tensor_adam_param_remainder exp_avg {i} mismatch for {backend_name}"
+                    )
+                    self.assert_close(
+                        exp_avg_sqs[i], ref_exp_avg_sqs[i], rtol=1e-5, atol=1e-7,
+                        msg=f"multi_tensor_adam_param_remainder exp_avg_sq {i} mismatch for {backend_name}"
+                    )
+                print(f"    ✓ {backend_name}")
+            except NotImplementedError:
+                self.skipped += 1
+                print(f"    ⊘ {backend_name} (not implemented)")
+            except Exception as e:
+                self.failed += 1
+                print(f"    ✗ {backend_name}: {e}")
+
     def _reference_multi_tensor_unscale_l2norm(self, tensors, inv_scale, per_tensor=False):
         """Reference implementation for multi_tensor_unscale_l2norm.
 
@@ -297,6 +446,9 @@ class OptimizerTests(TestCase):
 
         # multi_tensor_adam tests
         self.test_multi_tensor_adam(num_tensors=3, shape=(32, 64))
+
+        # multi_tensor_adam_param_remainder tests
+        self.test_multi_tensor_adam_param_remainder(num_tensors=3, shape=(32, 64))
 
         return self.report()
 

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -508,7 +508,6 @@ class _LayerNormLinear(torch.autograd.Function):
                     FP8GlobalStateManager.IS_FIRST_FP8_MODULE = _first_fp8_module
             ctx.wgrad_store = wgrad_store
             ctx.debug = debug
-            ctx.eps = eps
 
         # ------------------------------------------------------
         # Cached state for backward pass is ready...
@@ -972,7 +971,6 @@ class _LayerNormLinear(torch.autograd.Function):
                     ln_weight,
                     ctx.bwd_ln_sm_margin,
                     ctx.zero_centered_gamma,
-                    ctx.eps,
                 )
                 dgrad = dgrad.reshape(inputmat.size())
                 dbeta = None

--- a/transformer_engine/pytorch/ops/basic/rmsnorm.py
+++ b/transformer_engine/pytorch/ops/basic/rmsnorm.py
@@ -232,7 +232,6 @@ class RMSNorm(BasicOperation):
             w,
             self._sm_margins["backward"],
             self.zero_centered_gamma,
-            self.eps,
         )
 
         # Clear saved tensors if possible

--- a/transformer_engine/pytorch/optimizers/__init__.py
+++ b/transformer_engine/pytorch/optimizers/__init__.py
@@ -4,6 +4,8 @@
 
 """Fused optimizers and multi-tensor kernels."""
 from transformer_engine_torch import (
+    multi_tensor_scale,
+    multi_tensor_l2norm,
     multi_tensor_unscale_l2norm,
     multi_tensor_adam,
     multi_tensor_adam_fp8,

--- a/transformer_engine/pytorch/optimizers/__init__.py
+++ b/transformer_engine/pytorch/optimizers/__init__.py
@@ -4,8 +4,6 @@
 
 """Fused optimizers and multi-tensor kernels."""
 from transformer_engine_torch import (
-    multi_tensor_scale,
-    multi_tensor_l2norm,
     multi_tensor_unscale_l2norm,
     multi_tensor_adam,
     multi_tensor_adam_fp8,

--- a/transformer_engine/pytorch/optimizers/fused_adam.py
+++ b/transformer_engine/pytorch/optimizers/fused_adam.py
@@ -711,7 +711,7 @@ class FusedAdam(torch.optim.Optimizer):
                             self.multi_tensor_adam_param_remainder, tensor_lists
                         )
                     else:
-                        apply_multi_tensor_adam(self.multi_tensor_adam(), tensor_lists)
+                        apply_multi_tensor_adam(self.multi_tensor_adam, tensor_lists)
                 if len(p_fp8_model) > 0:
                     tensor_lists = [
                         g_of_fp8_model,
@@ -731,14 +731,14 @@ class FusedAdam(torch.optim.Optimizer):
                         m_of_f32_model,
                         v_of_f32_model,
                     ]
-                    apply_multi_tensor_adam(self.multi_tensor_adam(), tensor_lists)
+                    apply_multi_tensor_adam(self.multi_tensor_adam, tensor_lists)
             else:  # self.master_weights=False and self.capturable=False
                 if len(p_f16_model) > 0:
                     tensor_lists = [g_of_f16_model, p_f16_model, m_of_f16_model, v_of_f16_model]
-                    apply_multi_tensor_adam(self.multi_tensor_adam(), tensor_lists)
+                    apply_multi_tensor_adam(self.multi_tensor_adam, tensor_lists)
                 if len(p_f32_model) > 0:
                     tensor_lists = [g_of_f32_model, p_f32_model, m_of_f32_model, v_of_f32_model]
-                    apply_multi_tensor_adam(self.multi_tensor_adam(), tensor_lists)
+                    apply_multi_tensor_adam(self.multi_tensor_adam, tensor_lists)
 
             # Scaling
             for name in ["exp_avg", "exp_avg_sq", "master_param"]:


### PR DESCRIPTION
# Description            
                                                                                                                                                     
  Align TE_FL backend interface signatures with the upstream NVTE (NVIDIA TransformerEngine) C++ pybind API to      
  resolve parameter mismatches that cause runtime failures when TE_FL dispatches operations to different backends.
                                                                                                                                                     
  Motivation                                                                                                                                         

  The TEFLBackendBase abstract class and its concrete implementations (FlagOS, Reference, CUDA, Hygon, Iluvatar, MetaX) had function signatures that
  diverged from the NVTE pybind interface defined in transformer_engine/pytorch/csrc/extensions/pybind.cpp. This caused parameter name/type
  mismatches when the plugin layer forwarded calls to vendor backends, leading to TypeError exceptions at runtime.

  Changes

  1. Unified function signatures across the base class and all backends

  - generic_gemm: Renamed parameters to match NVTE pybind (transA→transa, transB→transb, output_dtype→out_dtype, workspace_size→workspaceSize,
  comm_type typed as CommOverlapType). Changed bias_type from Any to DType and return type from Any to List[Any].
  - rmsnorm_bwd: Renamed dy→dz to match NVTE convention. Removed the eps parameter from the signature (it is not passed by the NVTE caller). Made eps
   a keyword default in the FlagOS impl for backward compatibility.
  - layernorm_bwd: Renamed dy→dz to match NVTE convention.
  - rmsnorm_fwd / layernorm_fwd: Changed otype type from torch.dtype to DType enum.
  - multi_tensor_l2norm: Changed return type from Union[torch.Tensor, List[torch.Tensor]] to Tuple[torch.Tensor, torch.Tensor] to match the actual
  NVTE return convention.
  - multi_tensor_adam / multi_tensor_adam_param_remainder: Renamed eps→epsilon. Removed the "callable-when-no-args" pattern (returning the function
  itself when called with no arguments) — these methods now always execute the operation directly.
  - dropout_fwd / dropout_bwd: Made out / grad_input parameters required (non-optional) to match NVTE pybind.
  - Softmax functions: Renamed parameters (scale→scale_factor, output_grad→output_grad_, softmax_output→softmax_results_) to match NVTE naming.
  - get_fused_attn_backend: Replaced *args, **kwargs with explicit typed parameters matching the NVTE pybind signature.
  - multi_tensor_unscale_l2norm: Renamed scale→inv_scale for clarity.

  2. Added explicit signatures to previously stub-only methods in TEFLBackendBase

  - moe_permute_fwd, moe_permute_bwd, moe_unpermute_fwd, moe_unpermute_bwd
  - te_general_grouped_gemm, fp8_transpose, swap_first_dims
  - fused_attn_fwd, fused_attn_bwd, fa_prepare_fwd, fa_prepare_bwd
  - compute_amax, fused_amax_and_scale_update_after_reduction
  - fp8_block_scaling_compute_partial_amax, fp8_block_scaling_partial_cast
  - fused_multi_row_padding, fused_multi_row_unpadding
  - rmsnorm_bwd_add — replaced *args, **kwargs with explicit parameters

  3. Added DType enum conversion in the reference backend

  - Introduced _DTYPE_TO_TORCH_DTYPE mapping and _to_torch_dtype() helper in reference/impl/normalization.py to convert DType enum values to
  torch.dtype before computation.

  4. Cleaned up wrapper classes in ops.py

  - FP8TensorMeta, CommOverlapHelper, CommOverlap, CommOverlapP2P now use __new__ to route construction through the backend manager instead of
  raising NotImplementedError or holding dummy state.
  - Removed FusedAdamCUDAKernel and FusedSGDCUDAKernel stubs.

  5. Removed dead reference backend stubs

  - Removed ~30 raise NotImplementedError stub methods from ReferenceBackend and their corresponding OpImpl registrations in register_ops.py for
  operations that the reference backend cannot implement (NVSHMEM, THD, FP8, RoPE, MOE aux loss, etc.).

  6. Fixed FusedAdam optimizer call pattern

  - In fused_adam.py, changed self.multi_tensor_adam() (calling the method to get the function) to self.multi_tensor_adam (using the method
  directly), matching the new non-callable-return interface.

  7. Propagated rmsnorm_bwd signature change to PyTorch modules

  - Removed ctx.eps from layernorm_linear.py backward pass.
  - Removed self.eps from rmsnorm.py op_backward.

  8. Applied the same signature alignment to all vendor backends

  - CUDA, Hygon, Iluvatar, MetaX, and KunlunXin backends updated to match the new TEFLBackendBase signatures.

  9. Updated tests

  - test_normalization.py: Use DType.kFloat32 instead of torch.float32 for norm forward/backward calls. Removed eps from rmsnorm_bwd test calls.
  - test_operations.py: Use DType.kFloat32 for GEMM and pass explicit None for dropout optional params.
  - test_optimizer.py: Renamed eps→epsilon in multi_tensor_adam test. Added comprehensive multi_tensor_adam_param_remainder tests with
  FP32↔BF16+int16 split/reconstruct verification.


- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
