### PR TITLE
add multi_tensor_compute_scale_inv_e8m0 and change call erro

### DIFF
--- a/transformer_engine/plugin/core/backends/vendor/kunlunxin/kunlunxin.py
+++ b/transformer_engine/plugin/core/backends/vendor/kunlunxin/kunlunxin.py
@@ -356,7 +356,21 @@ class KunLunXinBackend(TEFLBackendBase):
         force_pow_2_scales: bool,
         epsilon: float,
     ) -> None:
-        tex = self._get_tex()
+        tex = tex._get_tex()
         return self.multi_tensor_compute_scale_and_scale_inv(
             chunk_size, noop_flag, tensor_lists, max_fp8, force_pow_2_scales, epsilon
+        )
+    def multi_tensor_compute_scale_inv_e8m0(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        block_len: int,
+    ) -> None:
+        tex = tex._get_tex()
+        return tex.multi_tensor_compute_scale_inv_e8m0(
+            chunk_size,
+            noop_flag,
+            tensor_lists,
+            block_len,
         )

--- a/transformer_engine/plugin/core/backends/vendor/kunlunxin/kunlunxin.py
+++ b/transformer_engine/plugin/core/backends/vendor/kunlunxin/kunlunxin.py
@@ -356,8 +356,8 @@ class KunLunXinBackend(TEFLBackendBase):
         force_pow_2_scales: bool,
         epsilon: float,
     ) -> None:
-        tex = tex._get_tex()
-        return self.multi_tensor_compute_scale_and_scale_inv(
+        tex = self._get_tex()
+        return tex.multi_tensor_compute_scale_and_scale_inv(
             chunk_size, noop_flag, tensor_lists, max_fp8, force_pow_2_scales, epsilon
         )
 
@@ -368,7 +368,7 @@ class KunLunXinBackend(TEFLBackendBase):
         tensor_lists: List[List[torch.Tensor]],
         block_len: int,
     ) -> None:
-        tex = tex._get_tex()
+        tex = self._get_tex()
         return tex.multi_tensor_compute_scale_inv_e8m0(
             chunk_size,
             noop_flag,

--- a/transformer_engine/plugin/core/backends/vendor/kunlunxin/kunlunxin.py
+++ b/transformer_engine/plugin/core/backends/vendor/kunlunxin/kunlunxin.py
@@ -360,6 +360,7 @@ class KunLunXinBackend(TEFLBackendBase):
         return self.multi_tensor_compute_scale_and_scale_inv(
             chunk_size, noop_flag, tensor_lists, max_fp8, force_pow_2_scales, epsilon
         )
+
     def multi_tensor_compute_scale_inv_e8m0(
         self,
         chunk_size: int,

--- a/transformer_engine/plugin/core/backends/vendor/kunlunxin/register_ops.py
+++ b/transformer_engine/plugin/core/backends/vendor/kunlunxin/register_ops.py
@@ -173,6 +173,14 @@ def register_builtins(registry) -> None:
             vendor="KUNLUNXIN",
             priority=100,
         ),
+        OpImpl(
+            op_name="multi_tensor_compute_scale_inv_e8m0",
+            impl_id="vendor.kunlunxin",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.multi_tensor_compute_scale_inv_e8m0, is_avail),
+            vendor="KUNLUNXIN",
+            priority=100,
+        ),
     ]
 
     registry.register_many(impls)


### PR DESCRIPTION
# Description

Added the binding and invocation for the `multi_tensor_compute_scale_inv_e8m0` operator for the Kunlunxin vendor, and corrected a syntax error in the invocation of the `multi_tensor_compute_scale_and_scale_inv` operator.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [1] Bug fix (non-breaking change which fixes an issue)
- [1] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Added code for the binding and invocation of the `multi_tensor_compute_scale_inv_e8m0` operator.
Modified the code calling `multi_tensor_compute_scale_and_scale_inv`.

# Checklist:

- [ 1] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ 1] The functionality is complete
- [ 1] I have commented my code, particularly in hard-to-understand areas
- [ 1] I have made corresponding changes to the documentation
- [ 1] My changes generate no new warnings
- [ 1] I have added tests that prove my fix is effective or that my feature works
- [ 1] New and existing unit tests pass locally with my changes
