### PR TITLE
[ascend]Native Integration of MegatronAdaptor (TransformerEngine-FL Module) on FlagOS

### DIFF
--- a/transformer_engine/__init__.py
+++ b/transformer_engine/__init__.py
@@ -24,6 +24,14 @@ try:
 except Exception as e:
     pass
 
+# Apply NPU (VENDOR) Patches, such as torch.cuda.device -> torch_npu.npu.device
+try:
+    from .plugin.core.backends.vendor.npu.patches import apply_patch as _npu_apply_patch
+
+    _npu_apply_patch()
+except Exception as e:
+    pass
+
 
 def te_device_type(default: str = "cuda") -> str:
     try:

--- a/transformer_engine/__init__.py
+++ b/transformer_engine/__init__.py
@@ -11,7 +11,7 @@ from importlib import metadata
 import transformer_engine.common
 
 import torch
-1
+
 # Public, simple global (kept for backward compatibility).
 TE_DEVICE_TYPE = "cuda"
 TE_PLATFORM = torch.cuda

--- a/transformer_engine/__init__.py
+++ b/transformer_engine/__init__.py
@@ -11,7 +11,7 @@ from importlib import metadata
 import transformer_engine.common
 
 import torch
-
+1
 # Public, simple global (kept for backward compatibility).
 TE_DEVICE_TYPE = "cuda"
 TE_PLATFORM = torch.cuda

--- a/transformer_engine/plugin/core/backends/vendor/npu/patches.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/patches.py
@@ -22,11 +22,8 @@ def get_npu_device_properties(device=None):
         uuid="fake-uuid-12345"
     )
 
-# Patches: (parent_object, attribute_name, replacement_callable)
 _PATCH_CALLS: list[tuple[object, str, Callable[..., object]]] = [
     # We do not recommend replace is_available, due to its device-related behavior.
-    # (torch.cuda, "is_available", torch.musa.is_available),
-    #(torch.cuda, "get_device_properties", torch_npu.npu.get_device_properties),
     (torch.cuda, "get_device_properties", get_npu_device_properties),
     (torch.cuda, "device", torch_npu.npu.device),
     (torch.cuda, "current_device", torch_npu.npu.current_device),

--- a/transformer_engine/plugin/core/backends/vendor/npu/patches.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/patches.py
@@ -39,10 +39,6 @@ _PATCH_CALLS: list[tuple[object, str, Callable[..., object]]] = [
 def apply_patch() -> None:
     """Apply NPU Python-side patches (idempotent, best-effort)."""
     try:
-        #from .npu import NPUBackend
-
-        #if not NPUBackend().is_available():
-        #    return
         import torch_npu
         if not torch_npu.npu.is_available():
             return

--- a/transformer_engine/plugin/core/backends/vendor/npu/patches.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/patches.py
@@ -36,9 +36,6 @@ _PATCH_CALLS: list[tuple[object, str, Callable[..., object]]] = [
     # TODO: Add other patches for NPU.
 ]
 
-#def get_npu_device_properties(device=None):
-#    return (9, 0)
-
 def apply_patch() -> None:
     """Apply NPU Python-side patches (idempotent, best-effort)."""
     try:

--- a/transformer_engine/plugin/core/backends/vendor/npu/patches.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/patches.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import torch
+
 try:
     import torch_npu
 except ImportError:
     pass
-1
+
 from types import SimpleNamespace
+
 
 def _noop(*args, **kwargs):
     return None
+
 
 def get_npu_device_properties(device=None):
     return SimpleNamespace(
@@ -22,8 +25,9 @@ def get_npu_device_properties(device=None):
         major=9,
         minor=0,
         multi_processor_count=80,
-        uuid="fake-uuid-12345"
+        uuid="fake-uuid-12345",
     )
+
 
 _PATCH_CALLS: list[tuple[object, str, Callable[..., object]]] = [
     # We do not recommend replace is_available, due to its device-related behavior.
@@ -39,10 +43,12 @@ _PATCH_CALLS: list[tuple[object, str, Callable[..., object]]] = [
     # TODO: Add other patches for NPU.
 ]
 
+
 def apply_patch() -> None:
     """Apply NPU Python-side patches (idempotent, best-effort)."""
     try:
         import torch_npu
+
         if not torch_npu.npu.is_available():
             return
 

--- a/transformer_engine/plugin/core/backends/vendor/npu/patches.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/patches.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import torch
-import torch_npu
+try:
+    import torch_npu
+except ImportError:
+    pass
 
 from types import SimpleNamespace
 

--- a/transformer_engine/plugin/core/backends/vendor/npu/patches.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/patches.py
@@ -1,0 +1,91 @@
+"""Python-side compatibility patches for the NPU vendor backend."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import torch
+import torch_npu
+
+from types import SimpleNamespace
+
+def _noop(*args, **kwargs):
+    return None
+
+def get_npu_device_properties(device=None):
+    return SimpleNamespace(
+        name="Fake NPU",
+        total_memory=16 * 1024**3,
+        major=9,
+        minor=0,
+        multi_processor_count=80,
+        uuid="fake-uuid-12345"
+    )
+
+# Patches: (parent_object, attribute_name, replacement_callable)
+_PATCH_CALLS: list[tuple[object, str, Callable[..., object]]] = [
+    # We do not recommend replace is_available, due to its device-related behavior.
+    # (torch.cuda, "is_available", torch.musa.is_available),
+    #(torch.cuda, "get_device_properties", torch_npu.npu.get_device_properties),
+    (torch.cuda, "get_device_properties", get_npu_device_properties),
+    (torch.cuda, "device", torch_npu.npu.device),
+    (torch.cuda, "current_device", torch_npu.npu.current_device),
+    (torch.cuda, "synchronize", torch_npu.npu.synchronize),
+    (torch.cuda, "is_current_stream_capturing", torch_npu.npu.is_current_stream_capturing),
+    # TODO: Add NVTX patches for NPU.
+    # NVTX is CUDA-specific; make it a no-op on NPU.
+    (torch.cuda.nvtx, "range_push", _noop),
+    (torch.cuda.nvtx, "range_pop", _noop),
+    # TODO: Add other patches for NPU.
+]
+
+#def get_npu_device_properties(device=None):
+#    return (9, 0)
+
+def apply_patch() -> None:
+    """Apply NPU Python-side patches (idempotent, best-effort)."""
+    try:
+        #from .npu import NPUBackend
+
+        #if not NPUBackend().is_available():
+        #    return
+        import torch_npu
+        if not torch_npu.npu.is_available():
+            return
+
+    except Exception as e:
+        print(f"[TE-FL] NPU backend not available: {e}")
+        # If backend availability can't be determined, don't patch.
+        return
+
+    # Mark TE global device type for Python-side callers.
+    # IMPORTANT: do not import `transformer_engine` here, because TE's `__init__.py`
+    # imports this module to run patches and that would cause a circular import.
+    try:
+        import transformer_engine
+
+        transformer_engine.TE_DEVICE_TYPE = "npu"
+        transformer_engine.TE_PLATFORM = torch_npu.npu
+    except Exception as e:
+        print(f"[TE-FL NPU Patches] Error setting TE device type or platform: {e}")
+        # Best-effort: don't fail patching if we can't set the global.
+        pass
+
+    # Only patch when torch_npu.npu exists and is usable.
+    if not hasattr(torch_npu, "npu"):
+        return
+    try:
+        if not torch_npu.npu.is_available():
+            return
+    except Exception:
+        return
+
+    for parent, attr, replacement in _PATCH_CALLS:
+        if not hasattr(parent, attr):
+            continue
+        try:
+            setattr(parent, attr, replacement)
+        except Exception:
+            # Best-effort: patching should never crash import/initialization.
+            continue
+    print(f"[TE-FL] NPU backend patches applied")

--- a/transformer_engine/plugin/core/backends/vendor/npu/patches.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/patches.py
@@ -9,7 +9,7 @@ try:
     import torch_npu
 except ImportError:
     pass
-
+1
 from types import SimpleNamespace
 
 def _noop(*args, **kwargs):


### PR DESCRIPTION
# Description

This PR optimizes the training entry of FlagScale, enabling native NPU training capability without introducing MegatronAdaptor dependencies.
1、Retain complete distributed training ability on NPU
2、No breaking changes to existing FlagScale training workflows
Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
