### PR TITLE
[fix] fix plugin te_general_grouped test bug

### DIFF
--- a/transformer_engine/plugin/tests/test_te_general_grouped.py
+++ b/transformer_engine/plugin/tests/test_te_general_grouped.py
@@ -22,7 +22,7 @@ class grouped_gemmTests(TestCase):
             "\n test te_general_grouped_gemm"
             f" grad:{grad} has_bias:{has_bias},has_pre_gelu:{has_pre_gelu},single_output:{single_output}"
         )
-        import transformer_engine_torch_nv as tex
+        import transformer_engine_torch as tex
 
         num_gemms = 2
         m, k, n = 128, 32, 64


### PR DESCRIPTION
## Summary

Replace the grouped GEMM plugin test import from `transformer_engine_torch_nv` to `transformer_engine_torch`.

## Why

The test should load the standard Transformer Engine torch extension module. Importing `transformer_engine_torch_nv` can fail because that is not the expected module name in this project.

## Impact

This fixes startup/import failure for `transformer_engine/plugin/tests/test_te_general_grouped.py` before the grouped GEMM checks run.

## Validation

- `git diff --check origin/main...HEAD`
- `python3 -c 'import ast, pathlib; path = pathlib.Path("transformer_engine/plugin/tests/test_te_general_grouped.py"); ast.parse(path.read_text())'`

Full test execution was not run locally because it requires the project runtime/CUDA environment.
