### PR TITLE
fix(hygon/platform): Improve Hygon library path resolution, fall back…

### DIFF
--- a/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
+++ b/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
@@ -37,7 +37,15 @@ def _load_hygon_libs():
         hygon_spec = importlib.util.find_spec("transformer_engine_hygon")
         if hygon_spec is None:
             return False
-        hygon_path = Path(hygon_spec.origin).parent
+        
+        if hygon_spec.origin is not None:
+            hygon_path = Path(hygon_spec.origin).parent
+        elif hygon_spec.submodule_search_locations:
+            hygon_path = Path(hygon_spec.submodule_search_locations[0])
+        else:
+            print("[ERROR _load_hygon_libs] cannot determine package path, origin is None and submodule_search_locations is empty")
+            return False
+        
         for file_path in hygon_path.iterdir():
             if file_path.name.startswith(common_prefix) and file_path.suffix == ext:
                 common_files.append(file_path)

--- a/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
+++ b/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
@@ -37,15 +37,16 @@ def _load_hygon_libs():
         hygon_spec = importlib.util.find_spec("transformer_engine_hygon")
         if hygon_spec is None:
             return False
-        
         if hygon_spec.origin is not None:
             hygon_path = Path(hygon_spec.origin).parent
         elif hygon_spec.submodule_search_locations:
             hygon_path = Path(hygon_spec.submodule_search_locations[0])
         else:
-            print("[ERROR _load_hygon_libs] cannot determine package path, origin is None and submodule_search_locations is empty")
+            print(
+                "[ERROR _load_hygon_libs] cannot determine package path, origin is None and"
+                " submodule_search_locations is empty"
+            )
             return False
-        
         for file_path in hygon_path.iterdir():
             if file_path.name.startswith(common_prefix) and file_path.suffix == ext:
                 common_files.append(file_path)


### PR DESCRIPTION
# Description

When loading Hygon libraries, the code previously assumed that
`hygon_spec.origin` is always available and directly accessed it to
determine the package path.

However, for namespace packages or certain installation layouts,
`importlib.util.find_spec()` may return a spec whose `origin` is `None`,
causing an exception when accessing `Path(hygon_spec.origin)`.

This PR adds a fallback mechanism:
- Use `hygon_spec.origin` when available.
- Fall back to `hygon_spec.submodule_search_locations` when `origin` is
  `None`.
- Return gracefully with an error message if neither source can provide
  a valid package path.

This improves compatibility with different Python package layouts and
prevents startup failures when loading Hygon-related libraries.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add a null check for `hygon_spec.origin`
- Fall back to `hygon_spec.submodule_search_locations[0]` when `origin` is unavailable
- Add explicit error handling when neither `origin` nor `submodule_search_locations` can determine the package path
- Prevent crashes caused by `Path(None)` during Hygon library loading

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes