### PR TITLE
hcu: implement multi_tensor_scale_tensor using multi_tensor_scale in transformer_engine_hygon 2.13

### DIFF
--- a/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
+++ b/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
@@ -1637,8 +1637,11 @@ class HygonBackend(TEFLBackendBase):
         tensor_lists: List[List[torch.Tensor]],
         scale: torch.Tensor,
     ) -> None:
+        # transform_engine_hygon does not support multi_tensor_scale_tensor
+        # (from upstream Nvidia TE v2.14). Use multi_tensor_scale as a workaround.
         tex = self._get_tex()
-        return tex.multi_tensor_scale_tensor(chunk_size, noop_flag, tensor_lists, scale)
+        scale_value = scale.item()
+        return tex.multi_tensor_scale(chunk_size, noop_flag, tensor_lists, scale_value)
 
     def multi_tensor_l2norm(
         self,

--- a/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
+++ b/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
@@ -37,7 +37,15 @@ def _load_hygon_libs():
         hygon_spec = importlib.util.find_spec("transformer_engine_hygon")
         if hygon_spec is None:
             return False
-        hygon_path = Path(hygon_spec.origin).parent
+        
+        if hygon_spec.origin is not None:
+            hygon_path = Path(hygon_spec.origin).parent
+        elif hygon_spec.submodule_search_locations:
+            hygon_path = Path(hygon_spec.submodule_search_locations[0])
+        else:
+            print("[ERROR _load_hygon_libs] cannot determine package path, origin is None and submodule_search_locations is empty")
+            return False
+        
         for file_path in hygon_path.iterdir():
             if file_path.name.startswith(common_prefix) and file_path.suffix == ext:
                 common_files.append(file_path)

--- a/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
+++ b/transformer_engine/plugin/core/backends/vendor/hygon/hygon.py
@@ -37,15 +37,16 @@ def _load_hygon_libs():
         hygon_spec = importlib.util.find_spec("transformer_engine_hygon")
         if hygon_spec is None:
             return False
-        
         if hygon_spec.origin is not None:
             hygon_path = Path(hygon_spec.origin).parent
         elif hygon_spec.submodule_search_locations:
             hygon_path = Path(hygon_spec.submodule_search_locations[0])
         else:
-            print("[ERROR _load_hygon_libs] cannot determine package path, origin is None and submodule_search_locations is empty")
+            print(
+                "[ERROR _load_hygon_libs] cannot determine package path, origin is None and"
+                " submodule_search_locations is empty"
+            )
             return False
-        
         for file_path in hygon_path.iterdir():
             if file_path.name.startswith(common_prefix) and file_path.suffix == ext:
                 common_files.append(file_path)


### PR DESCRIPTION
# Description

This PR fixes two compatibility issues in the Hygon backend.

First, it improves the package path resolution for `transformer_engine_hygon`. In some environments, `importlib.util.find_spec()` may return a `ModuleSpec` with `origin=None`, which causes the previous implementation to fail when resolving the package directory. This PR adds a fallback to `submodule_search_locations` and reports an error if neither source is available.

Second, `transformer_engine_hygon` currently does not implement the `multi_tensor_scale_tensor` API (available in upstream NVIDIA TransformerEngine v2.14). This PR replaces the unsupported call with the existing `multi_tensor_scale` implementation by extracting the scalar value from the input tensor, preserving equivalent functionality on the Hygon backend.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Improve `transformer_engine_hygon` package path resolution by handling the case where `ModuleSpec.origin` is `None`.
- Add a fallback to `submodule_search_locations` when locating Hygon backend libraries.
- Return a descriptive error when the package path cannot be determined.
- Replace the unsupported `multi_tensor_scale_tensor` call with `multi_tensor_scale` by converting the scale tensor to a scalar value.
- Add comments explaining the compatibility workaround for the Hygon backend.

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes