### PR TITLE
[Fix] reference backend general_gemm_torch

### DIFF
--- a/transformer_engine/plugin/core/backends/reference/impl/gemm.py
+++ b/transformer_engine/plugin/core/backends/reference/impl/gemm.py
@@ -5,6 +5,8 @@
 from typing import Any, Optional, Tuple, Union
 import torch
 
+from .activation import dgelu_torch
+
 __all__ = [
     "general_gemm_torch",
 ]
@@ -84,25 +86,33 @@ def general_gemm_torch(
     if alpha != 1.0:
         out = out * alpha
 
-    if original_B_shape is not None:
+    # A non-transposed B contributes its outer dimensions to the output. A
+    # transposed B does not, so its flattened shape must not be restored (the
+    # latter is the layout normally used by weight-gradient GEMMs).
+    if original_B_shape is not None and not transB:
         out = out.view(original_B_shape[0], original_B_shape[1], -1)
 
     gelu_input_ret = None
-    if gelu and gelu_in is not None:
-        pass
 
-    if bias is not None:
+    # In a backward GEMM, `bias` only requests the fused BGRAD epilogue. Its
+    # value is not added to the GEMM result.
+    if bias is not None and not grad:
         if bias.device != target_device:
             bias = bias.to(target_device)
         out = out + bias
 
     if gelu:
-        if gelu_in is not None:
-            gelu_in.copy_(out)
-            gelu_input_ret = gelu_in
+        if grad:
+            if gelu_in is None:
+                raise ValueError("gelu_in must be provided for a backward GELU GEMM")
+            out = dgelu_torch(out, gelu_in, quantizer=None)
         else:
-            gelu_input_ret = out.clone()
-        out = F.gelu(out, approximate="tanh")
+            if gelu_in is not None:
+                gelu_in.copy_(out)
+                gelu_input_ret = gelu_in
+            else:
+                gelu_input_ret = out.clone()
+            out = F.gelu(out, approximate="tanh")
 
     torch_out_dtype = _convert_dtype(output_dtype)
     if torch_out_dtype is not None and out.dtype != torch_out_dtype:
@@ -121,7 +131,9 @@ def general_gemm_torch(
 
     bias_grad = None
     if grad and bias is not None:
-        pass
+        # cuBLASLt's BGRADB epilogue always reduces GEMM input B. Flattening
+        # all leading dimensions also handles sequence-shaped gradient input.
+        bias_grad = B.sum(dim=0).to(dtype=out.dtype)
 
     extra_output_ret = None
 

--- a/transformer_engine/plugin/core/backends/reference/reference.py
+++ b/transformer_engine/plugin/core/backends/reference/reference.py
@@ -740,6 +740,52 @@ class ReferenceBackend(TEFLBackendBase):
             block_len,
         )
 
+    def convert_thd_to_bshd(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        b: int,
+        max_seq_len: int,
+    ) -> torch.Tensor:
+        """Convert THD (packed tokens) format to BSHD (batched, padded) format."""
+        # tensor shape: [total_tokens, num_heads, head_dim]
+        # output shape: [b, max_seq_len, num_heads, head_dim]
+        remaining_dims = tensor.shape[1:]
+        output = torch.zeros(
+            (b, max_seq_len) + remaining_dims,
+            dtype=tensor.dtype,
+            device=tensor.device,
+        )
+        for i in range(b):
+            start = cu_seqlens[i].item()
+            end = cu_seqlens[i + 1].item()
+            seq_len = end - start
+            output[i, :seq_len] = tensor[start:end]
+        return output
+
+    def convert_bshd_to_thd(
+        self,
+        tensor: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        t: int,
+    ) -> torch.Tensor:
+        """Convert BSHD (batched, padded) format to THD (packed tokens) format."""
+        # tensor shape: [b, max_seq_len, num_heads, head_dim]
+        # output shape: [t, num_heads, head_dim]
+        b = tensor.shape[0]
+        remaining_dims = tensor.shape[2:]
+        output = torch.zeros(
+            (t,) + remaining_dims,
+            dtype=tensor.dtype,
+            device=tensor.device,
+        )
+        for i in range(b):
+            start = cu_seqlens[i].item()
+            end = cu_seqlens[i + 1].item()
+            seq_len = end - start
+            output[start:end] = tensor[i, :seq_len]
+        return output
+
     def get_flash_attention_class(self):
         from .flash_attention import FlashAttentionTorch
 

--- a/transformer_engine/plugin/core/backends/reference/register_ops.py
+++ b/transformer_engine/plugin/core/backends/reference/register_ops.py
@@ -516,6 +516,23 @@ def register_builtins(registry) -> None:
             vendor=None,
             priority=50,
         ),
+        # THD <-> BSHD format conversion
+        OpImpl(
+            op_name="convert_thd_to_bshd",
+            impl_id="reference.torch",
+            kind=BackendImplKind.REFERENCE,
+            fn=_bind_is_available(backend.convert_thd_to_bshd, is_avail),
+            vendor=None,
+            priority=50,
+        ),
+        OpImpl(
+            op_name="convert_bshd_to_thd",
+            impl_id="reference.torch",
+            kind=BackendImplKind.REFERENCE,
+            fn=_bind_is_available(backend.convert_bshd_to_thd, is_avail),
+            vendor=None,
+            priority=50,
+        ),
         # FlashAttention class getter
         OpImpl(
             op_name="get_flash_attention_class",

--- a/transformer_engine/plugin/tests/test_backend_reference_gemm.py
+++ b/transformer_engine/plugin/tests/test_backend_reference_gemm.py
@@ -425,9 +425,8 @@ def test_gemm_backward_with_gelu():
     sqrt_2_over_pi = 0.7978845608028654
     u = sqrt_2_over_pi * (x + 0.044715 * x.pow(3))
     tanh_u = torch.tanh(u)
-    gelu_deriv = (
-        0.5 * (1.0 + tanh_u)
-        + 0.5 * x * (1.0 - tanh_u.pow(2)) * sqrt_2_over_pi * (1.0 + 3.0 * 0.044715 * x.pow(2))
+    gelu_deriv = 0.5 * (1.0 + tanh_u) + 0.5 * x * (1.0 - tanh_u.pow(2)) * sqrt_2_over_pi * (
+        1.0 + 3.0 * 0.044715 * x.pow(2)
     )
     expected_out = dY * gelu_deriv
 

--- a/transformer_engine/plugin/tests/test_backend_reference_gemm.py
+++ b/transformer_engine/plugin/tests/test_backend_reference_gemm.py
@@ -303,3 +303,209 @@ def test_gemm_accumulator_destinations():
     )
     assert res_c is D_c
     assert D_c.item() == 2.0
+
+
+# ==============================================================================
+# Part 4: Backward Pass (grad=True) Tests
+# ==============================================================================
+
+
+def test_gemm_backward_bias_grad():
+    """Verify bias gradient computation when grad=True and bias is provided.
+
+    In backward mode the function should:
+    - NOT add bias to the output
+    - Return bias_grad = B.sum(dim=0) (gradient w.r.t. bias)
+    """
+    # A (K, N) = (3, 2), B (M, K) = (4, 3)
+    # transA=False, transB=False -> out = mm(B_comp, A_comp) = mm((4,3),(3,2)) = (4,2)
+    A = torch.randn(3, 2, dtype=torch.float32)
+    B = torch.randn(4, 3, dtype=torch.float32)
+    bias = torch.ones(2, dtype=torch.float32)  # shape matches output columns
+
+    res, bias_grad, _, _ = general_gemm_torch(
+        A=A,
+        transA=False,
+        B=B,
+        transB=False,
+        D=None,
+        quantizer=None,
+        output_dtype=None,
+        bias=bias,
+        bias_type=None,
+        gelu=False,
+        gelu_in=None,
+        grad=True,
+        workspace=torch.empty(1),
+        workspace_size=0,
+        accumulate=False,
+        use_split_accumulator=False,
+    )
+
+    # bias_grad should equal B.sum(dim=0)
+    expected_bias_grad = B.sum(dim=0)
+    assert bias_grad is not None
+    assert torch.allclose(bias_grad, expected_bias_grad)
+
+    # Output should NOT include bias (compare with plain matmul)
+    expected_out = torch.mm(B, A)
+    assert torch.allclose(res, expected_out)
+
+
+def test_gemm_backward_no_bias():
+    """Verify that grad=True with bias=None returns bias_grad=None and computes normally."""
+    A = torch.randn(3, 2, dtype=torch.float32)
+    B = torch.randn(4, 3, dtype=torch.float32)
+
+    res, bias_grad, _, _ = general_gemm_torch(
+        A=A,
+        transA=False,
+        B=B,
+        transB=False,
+        D=None,
+        quantizer=None,
+        output_dtype=None,
+        bias=None,
+        bias_type=None,
+        gelu=False,
+        gelu_in=None,
+        grad=True,
+        workspace=torch.empty(1),
+        workspace_size=0,
+        accumulate=False,
+        use_split_accumulator=False,
+    )
+
+    assert bias_grad is None
+    expected_out = torch.mm(B, A)
+    assert torch.allclose(res, expected_out)
+
+
+def test_gemm_backward_with_gelu():
+    """Verify backward behavior when both grad=True and gelu=True.
+
+    In backward pass, out = dY (upstream gradient) and gelu_in holds the
+    pre-activation from forward. The result should be dY * GeLU'(gelu_in).
+
+    GeLU(x) = 0.5 * x * (1 + tanh(u)),  u = sqrt(2/pi) * (x + 0.044715 * x^3)
+    GeLU'(x) = 0.5*(1+tanh(u)) + 0.5*x*(1-tanh(u)^2)*sqrt(2/pi)*(1+3*0.044715*x^2)
+    """
+    A = torch.randn(3, 2, dtype=torch.float32)
+    B = torch.randn(4, 3, dtype=torch.float32)
+
+    # Simulate: gelu_in was saved during forward with some known values
+    gelu_buffer = torch.randn(4, 2, dtype=torch.float32)
+    saved_gelu_in = gelu_buffer.clone()  # preserve original values
+
+    res, bias_grad, gelu_in_ret, _ = general_gemm_torch(
+        A=A,
+        transA=False,
+        B=B,
+        transB=False,
+        D=None,
+        quantizer=None,
+        output_dtype=None,
+        bias=None,
+        bias_type=None,
+        gelu=True,
+        gelu_in=gelu_buffer,
+        grad=True,
+        workspace=torch.empty(1),
+        workspace_size=0,
+        accumulate=False,
+        use_split_accumulator=False,
+    )
+
+    # gelu_in_ret should be the same buffer, unchanged (backward reads it, doesn't overwrite)
+    assert gelu_in_ret is gelu_buffer
+
+    # Compute expected: dY * GeLU'(saved_gelu_in)
+    dY = torch.mm(B, A)  # the matmul result before gelu backward
+    x = saved_gelu_in
+    sqrt_2_over_pi = 0.7978845608028654
+    u = sqrt_2_over_pi * (x + 0.044715 * x.pow(3))
+    tanh_u = torch.tanh(u)
+    gelu_deriv = (
+        0.5 * (1.0 + tanh_u)
+        + 0.5 * x * (1.0 - tanh_u.pow(2)) * sqrt_2_over_pi * (1.0 + 3.0 * 0.044715 * x.pow(2))
+    )
+    expected_out = dY * gelu_deriv
+
+    assert torch.allclose(res, expected_out, atol=1e-6)
+
+
+def test_gemm_backward_bias_grad_with_alpha():
+    """Verify bias gradient is independent of alpha scaling.
+
+    The bias_grad = B.sum(dim=0) should not be affected by alpha, since alpha
+    only scales the matmul output.
+    """
+    A = torch.randn(3, 2, dtype=torch.float32)
+    B = torch.randn(4, 3, dtype=torch.float32)
+    bias = torch.ones(2, dtype=torch.float32)
+
+    res, bias_grad, _, _ = general_gemm_torch(
+        A=A,
+        transA=False,
+        B=B,
+        transB=False,
+        D=None,
+        quantizer=None,
+        output_dtype=None,
+        bias=bias,
+        bias_type=None,
+        gelu=False,
+        gelu_in=None,
+        grad=True,
+        workspace=torch.empty(1),
+        workspace_size=0,
+        accumulate=False,
+        use_split_accumulator=False,
+        alpha=0.5,
+    )
+
+    # bias_grad = B.sum(dim=0), unaffected by alpha
+    expected_bias_grad = B.sum(dim=0)
+    assert torch.allclose(bias_grad, expected_bias_grad)
+
+    # Output should be scaled by alpha
+    expected_out = torch.mm(B, A) * 0.5
+    assert torch.allclose(res, expected_out)
+
+
+def test_gemm_backward_bias_grad_3d_input():
+    """Verify bias gradient computation with 3D B tensor (batch dimension)."""
+    # B is 3D: (2, 3, 4) -> reshaped to (6, 4)
+    # A is 2D: (4, 2), transA=False
+    # out = mm((6,4), (4,2)) = (6,2), then reshaped to (2, 3, 2)
+    A = torch.randn(4, 2, dtype=torch.float32)
+    B = torch.randn(2, 3, 4, dtype=torch.float32)
+    bias = torch.ones(2, dtype=torch.float32)
+
+    res, bias_grad, _, _ = general_gemm_torch(
+        A=A,
+        transA=False,
+        B=B,
+        transB=False,
+        D=None,
+        quantizer=None,
+        output_dtype=None,
+        bias=bias,
+        bias_type=None,
+        gelu=False,
+        gelu_in=None,
+        grad=True,
+        workspace=torch.empty(1),
+        workspace_size=0,
+        accumulate=False,
+        use_split_accumulator=False,
+    )
+
+    # B is reshaped to (6, 4) before bias_grad = B.sum(dim=0) -> shape (4,)
+    B_reshaped = B.reshape(-1, B.shape[-1])
+    expected_bias_grad = B_reshaped.sum(dim=0)
+    assert bias_grad is not None
+    assert torch.allclose(bias_grad, expected_bias_grad)
+
+    # Output should be reshaped back to (2, 3, 2)
+    assert res.shape == (2, 3, 2)


### PR DESCRIPTION
# Description

This PR fixes `general_gemm_torch` in the reference backend to better align its forward and backward behavior with fused GEMM semantics.

In backward mode, bias is now treated as a request for the BGRAD epilogue instead of being added to the GEMM output. The implementation now computes the bias gradient from the flattened input, supports GeLU backward using the saved pre-activation tensor, and correctly handles output shape restoration for transposed and non-transposed inputs.

This PR also adds and registers reference implementations for THD ↔ BSHD tensor layout conversion.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation change
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Do not add `bias` to the GEMM output when `grad=True`.
- Compute `bias_grad` by reducing the flattened GEMM input.
- Apply GeLU backward through `dgelu_torch` using `gelu_in`.
- Require `gelu_in` when running a backward GeLU GEMM.
- Restore the original batched output shape only when `B` is not transposed.
- Add reference implementations for THD-to-BSHD and BSHD-to-THD conversion.
- Register the new tensor-layout conversion operations in the reference backend.
- Add regression tests covering:
  - backward GEMM with and without bias;
  - fused GeLU backward;
  - alpha scaling with bias-gradient computation;
  - three-dimensional GEMM inputs and output shapes.

## Test plan

Added unit tests in `test_backend_reference_gemm.py` for the corrected backward behavior and shape handling.

CI is currently in progress.