### PR TITLE
[CICD] Add BW1000 reference CI baseline and standardize plugin tests

### DIFF
--- a/.github/configs/hygon.yml
+++ b/.github/configs/hygon.yml
@@ -1,0 +1,76 @@
+# Hygon DCU / DTK configuration for TransformerEngine-FL plugin QA.
+
+hardware_name: hygon
+display_name: 'Hygon DCU (DTK)'
+checkout_submodules: 'false'
+
+ci_image: harbor.baai.ac.cn/flagos-dev/transformerengine-fl:manual-20260717-hygon-dev
+
+runner_labels:
+  - hg-8g-cicd-te
+
+container_volumes:
+  - /opt/hyhal:/opt/hyhal
+
+container_options: >-
+  --privileged
+  --ipc=host
+  --shm-size=100g
+  --ulimit memlock=-1
+  --ulimit stack=67108864
+  --user root
+  --device=/dev/kfd
+  --device=/dev/dri
+  --group-add video
+
+setup_script: .github/scripts/setup_hygon.sh
+
+coverage:
+  enabled: true
+  required: false
+  python: python3
+  sources:
+    - transformer_engine
+  include:
+    - transformer_engine/pytorch/*
+    - transformer_engine/debug/*
+    - transformer_engine/plugin/*
+  omit:
+    - '*/setup.py'
+    - '*/transformer_engine/plugin/core/_build_config.py'
+
+unit_test_matrix:
+  - name: pytorch_debug
+    runner: script
+    path: tests/plugin/backend/hygon/run_native.sh
+    args: [debug]
+    env:
+      XML_LOG_DIR: logs/L0_pytorch_debug_unittest-hygon
+
+  - name: pytorch_unittest
+    runner: script
+    path: tests/plugin/backend/hygon/run_native.sh
+    args: [unittest]
+    env:
+      XML_LOG_DIR: logs/L0_pytorch_unittest-hygon
+
+  - name: pytorch_distributed_unittest
+    runner: script
+    path: tests/plugin/backend/hygon/run_native.sh
+    args: [distributed]
+    env:
+      XML_LOG_DIR: logs/L1_pytorch_distributed_unittest-hygon
+
+  - name: pytorch_onnx_unittest
+    runner: script
+    path: tests/plugin/backend/hygon/run_native.sh
+    args: [onnx]
+    env:
+      XML_LOG_DIR: logs/L1_pytorch_onnx_unittest-hygon
+
+integration_test_matrix:
+  - name: pytorch_mcore_integration
+    path: tests/plugin/backend/hygon/run_integration.sh
+
+device_types:
+  - bw1000

--- a/.github/scripts/setup_hygon.sh
+++ b/.github/scripts/setup_hygon.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Hygon/DTK environment setup for TransformerEngine-FL plugin QA.
+set -euo pipefail
+
+WORKSPACE="${GITHUB_WORKSPACE:-$(pwd)}"
+
+echo "===== Load Hygon/DTK runtime environment ====="
+source "$WORKSPACE/tests/plugin/backend/hygon/set_env.sh"
+
+echo "===== Verify Hygon device visibility ====="
+if [ "${HYGON_REQUIRE_DEVICE:-1}" = "1" ] && ! command -v hy-smi >/dev/null 2>&1; then
+    echo "ERROR: hy-smi is unavailable in the Hygon CI image" >&2
+    exit 1
+elif command -v hy-smi >/dev/null 2>&1; then
+    hy-smi
+else
+    echo "WARNING: hy-smi is unavailable; device verification is disabled"
+fi
+
+echo "===== Verify Python runtime ====="
+"$PYTHON_BIN" - <<'PY'
+import os
+import sys
+
+print("python:", sys.executable)
+print("version:", sys.version)
+
+try:
+    import torch
+except ModuleNotFoundError as exc:
+    raise SystemExit(f"PyTorch is required in the Hygon CI image: {exc}") from exc
+
+print("torch:", torch.__version__)
+
+if os.environ.get("HYGON_REQUIRE_DEVICE", "1") == "1":
+    if not torch.cuda.is_available():
+        raise SystemExit("Hygon DCU is not visible through torch.cuda")
+
+    device_count = torch.cuda.device_count()
+    if device_count < 1:
+        raise SystemExit("torch.cuda reports zero Hygon devices")
+
+    device = torch.device("cuda")
+    lhs = torch.ones((2, 2), device=device)
+    rhs = torch.full((2, 2), 2.0, device=device)
+    result = lhs @ rhs
+    if not torch.allclose(result.cpu(), torch.full((2, 2), 4.0)):
+        raise SystemExit("Hygon DCU matrix-multiplication smoke test failed")
+
+    print("cuda_device_count:", device_count)
+    print("cuda_device_name:", torch.cuda.get_device_name(0))
+    print("matmul_smoke: passed")
+PY
+
+echo "===== Verify reference backend selection ====="
+"$PYTHON_BIN" - <<'PY'
+from transformer_engine.plugin.core import get_manager
+
+manager = get_manager()
+selected_impl = manager.get_selected_impl_id("generic_gemm")
+if selected_impl != "reference.torch":
+    raise SystemExit(
+        f"Expected generic_gemm to use reference.torch, selected {selected_impl!r}"
+    )
+print("generic_gemm_impl:", selected_impl)
+PY
+
+echo "===== Install Hygon QA dependencies ====="
+if [ "${HYGON_SKIP_DEP_INSTALL:-0}" = "1" ]; then
+    echo "Skipping Python dependency installation because HYGON_SKIP_DEP_INSTALL=1"
+else
+    missing_modules=()
+    for module_name in pytest expecttest coverage pytest_cov; do
+        if ! "$PYTHON_BIN" -c "import importlib; importlib.import_module('$module_name')" >/dev/null 2>&1; then
+            missing_modules+=("$module_name")
+        fi
+    done
+
+    if [ "${#missing_modules[@]}" -gt 0 ]; then
+        echo "Missing Hygon QA modules: ${missing_modules[*]}"
+        "$PYTHON_BIN" -m pip install pytest==8.2.1 expecttest coverage pytest-cov
+    else
+        echo "Hygon QA dependencies are already available in the image"
+    fi
+
+    # ONNX dependencies are installed only by the ONNX test group.
+fi
+
+"$PYTHON_BIN" -c "import coverage, pytest_cov; print('coverage dependencies: ready')"
+
+if [ "${HYGON_INSTALL_TE:-0}" = "1" ]; then
+    echo "===== Install TransformerEngine-FL Python layer ====="
+    cd "$WORKSPACE"
+    TE_FL_SKIP_CUDA=1 "$PYTHON_BIN" setup.py install
+else
+    echo "Skipping TransformerEngine-FL install; tests run from source via PYTHONPATH"
+fi
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+    {
+        echo "PATH=$PATH"
+        echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}"
+        echo "PYTHONPATH=$WORKSPACE${PYTHONPATH:+:$PYTHONPATH}"
+        echo "TE_PATH=$WORKSPACE"
+        echo "XML_LOG_DIR=$WORKSPACE/logs"
+        echo "PLATFORM=$PLATFORM"
+        echo "TE_FL_SKIP_CUDA=$TE_FL_SKIP_CUDA"
+        echo "TE_FL_PREFER=$TE_FL_PREFER"
+        echo "NVTE_FRAMEWORK=$NVTE_FRAMEWORK"
+        echo "PYTHON_BIN=$PYTHON_BIN"
+        echo "NVTE_FLASH_ATTN=$NVTE_FLASH_ATTN"
+        echo "NVTE_FUSED_ATTN=$NVTE_FUSED_ATTN"
+        echo "NVTE_UNFUSED_ATTN=$NVTE_UNFUSED_ATTN"
+        echo "NVTE_UnfusedDPA_Emulate_FP8=$NVTE_UnfusedDPA_Emulate_FP8"
+        echo "HYGON_REQUIRE_DEVICE=${HYGON_REQUIRE_DEVICE:-1}"
+    } >> "$GITHUB_ENV"
+fi
+
+echo "===== Hygon environment setup complete ====="

--- a/.github/scripts/setup_hygon.sh
+++ b/.github/scripts/setup_hygon.sh
@@ -7,6 +7,16 @@ WORKSPACE="${GITHUB_WORKSPACE:-$(pwd)}"
 echo "===== Load Hygon/DTK runtime environment ====="
 source "$WORKSPACE/tests/plugin/backend/hygon/set_env.sh"
 
+# Hygon CI is a reference-backend baseline. Force the selection policy here so
+# inherited shell state cannot silently fall back to FlagOS.
+export TE_FL_SKIP_CUDA=1
+export TE_FL_PREFER=reference
+export NVTE_FRAMEWORK=pytorch
+export NVTE_FLASH_ATTN=0
+export NVTE_FUSED_ATTN=0
+export NVTE_UNFUSED_ATTN=1
+export NVTE_UnfusedDPA_Emulate_FP8=1
+
 echo "===== Verify Hygon device visibility ====="
 if [ "${HYGON_REQUIRE_DEVICE:-1}" = "1" ] && ! command -v hy-smi >/dev/null 2>&1; then
     echo "ERROR: hy-smi is unavailable in the Hygon CI image" >&2

--- a/.github/workflows/all_tests_hygon.yml
+++ b/.github/workflows/all_tests_hygon.yml
@@ -1,0 +1,35 @@
+name: hygon_tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.actor }}
+  cancel-in-progress: true
+
+jobs:
+  run_tests:
+    # Package manager and environment settings are read from .github/configs/hygon.yml
+    uses: ./.github/workflows/all_tests_common.yml
+    with:
+      platform: hygon
+      run_unit_tests: true
+      # Hygon currently gates the DCU-hosted reference baseline only.
+      run_integration_tests: true
+
+  all_tests:
+    needs: run_tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Verify workflow status
+        run: |
+          if [ "${{ needs.run_tests.result }}" != "success" ]; then
+            echo "Hygon tests workflow failed"
+            exit 1
+          fi
+          echo "All Hygon tests passed!"

--- a/tests/plugin/backend/hygon/__init__.py
+++ b/tests/plugin/backend/hygon/__init__.py
@@ -1,0 +1,1 @@
+"""Hygon/DTK test bootstrap and reference-baseline runner."""

--- a/tests/plugin/backend/hygon/config.sh
+++ b/tests/plugin/backend/hygon/config.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Hygon/DTK workflow configuration. Keep backend-specific selection policy
+# here, and keep the runner focused on executing explicitly supported tests.
+
+HYGON_ONNX_SKIP_GROUPS=(
+    "test_export_linear"
+    "test_export_layernorm_linear"
+    "test_export_layernorm_mlp"
+    "test_export_core_attention"
+    "test_export_transformer_layer"
+    "test_export_multihead_attention"
+    "test_export_gpt_generation"
+)

--- a/tests/plugin/backend/hygon/run_integration.sh
+++ b/tests/plugin/backend/hygon/run_integration.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep Hygon's reference-baseline integration parameters in the Hygon-owned
+# entrypoint. The common integration workflow intentionally only executes the
+# configured script and does not interpret platform-specific matrix fields.
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../../../.." && pwd)"
+
+source "$SCRIPT_DIR/set_env.sh"
+
+export PLATFORM="hygon"
+export TE_FL_PREFER="reference"
+export MCORE_REPO_URL="${MCORE_REPO_URL:-https://github.com/flagos-ai/Megatron-LM-FL.git}"
+export MCORE_REF="${MCORE_REF:-175ae90ec92a9e6fea2d74ccd24d6a1835d3ae82}"
+export DISTRIBUTED_BACKEND="${DISTRIBUTED_BACKEND:-nccl}"
+export NUM_LAYERS="${NUM_LAYERS:-2}"
+export HIDDEN_SIZE="${HIDDEN_SIZE:-128}"
+export NUM_ATTENTION_HEADS="${NUM_ATTENTION_HEADS:-4}"
+export SEQ_LENGTH="${SEQ_LENGTH:-128}"
+export MICRO_BATCH_SIZE="${MICRO_BATCH_SIZE:-1}"
+export GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-1}"
+export ENABLE_DIAGNOSTICS="${ENABLE_DIAGNOSTICS:-0}"
+
+exec bash "$REPO_ROOT/qa/L1_pytorch_mcore_integration/test.sh"

--- a/tests/plugin/backend/hygon/run_native.sh
+++ b/tests/plugin/backend/hygon/run_native.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/set_env.sh"
+source "$SCRIPT_DIR/config.sh"
+
+PYTHON="${PYTHON_BIN:-python3}"
+FAIL=0
+FAILED_CASES=()
+
+usage() {
+    cat <<'EOF'
+Usage: tests/plugin/backend/hygon/run_native.sh [debug] [unittest] [distributed] [onnx]
+
+Runs the selected Hygon/DTK reference-baseline test group.
+If no suite is specified, all suites are run.
+EOF
+}
+
+join_with_or() {
+    local result=""
+    local item
+    for item in "$@"; do
+        if [ -z "$result" ]; then
+            result="$item"
+        else
+            result="$result or $item"
+        fi
+    done
+    printf '%s' "$result"
+}
+
+python_has_module() {
+    "$PYTHON" - "$1" <<'PY'
+import importlib
+import sys
+
+try:
+    importlib.import_module(sys.argv[1])
+except ModuleNotFoundError:
+    raise SystemExit(1)
+PY
+}
+
+install_python_package() {
+    local module_name=$1
+    local package_spec=$2
+
+    if python_has_module "$module_name"; then
+        return 0
+    fi
+
+    if [ "${HYGON_SKIP_DEP_INSTALL:-0}" = "1" ]; then
+        echo "ERROR: Python module '$module_name' is missing and dependency installation is disabled" >&2
+        return 1
+    fi
+
+    "$PYTHON" -m pip install "$package_spec"
+}
+
+skip_step() {
+    local label=$1
+    local reason=$2
+    echo "-------------------------------------------------------"
+    echo "[SKIP] Hygon/DTK: $label ($reason)"
+    echo "-------------------------------------------------------"
+}
+
+run_cmd() {
+    local suite=$1
+    local label=$2
+    local xml_name=$3
+    shift 3
+
+    echo "-------------------------------------------------------"
+    echo "[RUN][$suite] $label"
+    echo "-------------------------------------------------------"
+    if ! "$@" --junitxml="$XML_LOG_DIR/$xml_name"; then
+        FAIL=1
+        FAILED_CASES+=("$suite:$label")
+        echo "Error: sub-test failed: $suite:$label"
+    fi
+}
+
+run_pytest_step() {
+    local label=$1
+    local xml_name=$2
+    shift 2
+    run_cmd "unittest" "$label" "$xml_name" "$@"
+}
+
+run_distributed_step() {
+    local label=$1
+    local xml_name=$2
+    shift 2
+    run_cmd "distributed" "$label" "$xml_name" "$@"
+}
+
+install_base_deps() {
+    install_python_package pytest "${PYTEST_PACKAGE_SPEC:-pytest==8.2.1}"
+}
+
+install_l0_deps() {
+    install_base_deps
+    install_python_package expecttest "${EXPECTTEST_PACKAGE_SPEC:-expecttest}"
+}
+
+install_onnx_deps() {
+    install_python_package onnxruntime "${ONNXRUNTIME_PACKAGE_SPEC:-onnxruntime}"
+    install_python_package onnxruntime_extensions "${ONNXRUNTIME_EXTENSIONS_PACKAGE_SPEC:-onnxruntime_extensions}"
+    install_base_deps
+}
+
+run_debug_suite() {
+    echo "===== START debug $(date '+%F %T') ====="
+    install_base_deps
+
+    if ! "$PYTHON" -c "import nvdlfw_inspect.api" >/dev/null 2>&1; then
+        skip_step "tests/pytorch/debug/*" "nvdlfw_inspect is unavailable"
+        skip_step "tests/pytorch/test_sanity.py" "debug nvinspect path not required by current DTK plugin workflow"
+        skip_step "tests/pytorch/test_numerics.py" "debug nvinspect path not required by current DTK plugin workflow"
+        echo "===== END debug rc=0 $(date '+%F %T') ====="
+        return 0
+    fi
+
+    local feature_dirs="${NVTE_TEST_NVINSPECT_FEATURE_DIRS:-$TE_PATH/transformer_engine/debug/features}"
+    local configs_dir="${NVTE_TEST_NVINSPECT_CONFIGS_DIR:-$TE_PATH/tests/pytorch/debug/test_configs}"
+    local dummy_config="${NVTE_TEST_NVINSPECT_DUMMY_CONFIG_FILE:-$TE_PATH/tests/pytorch/debug/test_configs/dummy_feature.yaml}"
+
+    run_cmd "debug" "debug/test_config.py" "test_config.xml" \
+        "$PYTHON" -m pytest -v -s "$TE_PATH/tests/pytorch/debug/test_config.py" \
+        --feature_dirs="$feature_dirs"
+    run_cmd "debug" "debug/test_log.py" "test_log.xml" \
+        "$PYTHON" -m pytest -v -s "$TE_PATH/tests/pytorch/debug/test_log.py" \
+        --feature_dirs="$feature_dirs" --configs_dir="$configs_dir"
+    run_cmd "debug" "debug/test_api_features.py" "test_api_features.xml" \
+        env NVTE_TORCH_COMPILE=0 "$PYTHON" -m pytest -v -s "$TE_PATH/tests/pytorch/debug/test_api_features.py" \
+        --no-header --feature_dirs="$feature_dirs" --configs_dir="$configs_dir"
+    run_cmd "debug" "test_sanity.py (nvinspect)" "test_sanity_2.xml" \
+        env NVTE_TEST_NVINSPECT_ENABLED=1 \
+        NVTE_TEST_NVINSPECT_CONFIG_FILE="$dummy_config" \
+        NVTE_TEST_NVINSPECT_FEATURE_DIRS="$feature_dirs" \
+        PYTORCH_JIT=0 NVTE_TORCH_COMPILE=0 NVTE_ALLOW_NONDETERMINISTIC_ALGO=0 \
+        "$PYTHON" -m pytest -v -s "$TE_PATH/tests/pytorch/test_sanity.py" --no-header
+
+    echo "===== END debug rc=$FAIL $(date '+%F %T') ====="
+}
+
+run_unittest_suite() {
+    echo "===== START unittest $(date '+%F %T') ====="
+    install_l0_deps
+
+    # Keep this group limited to upstream smoke tests that exercise the
+    # reference path on a real Hygon device.
+    run_pytest_step "test_deferred_init.py" "pytest_test_deferred_init.xml" \
+        "$PYTHON" -m pytest -s -v --tb=auto "$TE_PATH/tests/pytorch/test_deferred_init.py"
+    run_pytest_step "test_jit.py" "pytest_test_jit.xml" \
+        "$PYTHON" -m pytest -s -v --tb=auto "$TE_PATH/tests/pytorch/test_jit.py" -k "not (test_torch_dynamo)"
+
+    local plugin_root="$TE_PATH/tests/plugin"
+    run_pytest_step "plugin/test_policy.py" "pytest_test_plugin_policy.xml" \
+        "$PYTHON" -m pytest -s -v --tb=auto "$plugin_root/plugin/test_policy.py"
+    run_pytest_step "plugin/test_manager.py" "pytest_test_plugin_manager.xml" \
+        "$PYTHON" -m pytest -s -v --tb=auto "$plugin_root/plugin/test_manager.py"
+    run_pytest_step "plugin/test_policy_selection.py" "pytest_test_plugin_policy_selection.xml" \
+        "$PYTHON" -m pytest -s -v --tb=auto "$plugin_root/plugin/test_policy_selection.py"
+    run_pytest_step "reference/test_lifecycle.py" "pytest_test_backend_reference.xml" \
+        "$PYTHON" -m pytest -s -v --tb=auto "$plugin_root/backend/reference/test_lifecycle.py"
+    run_pytest_step "reference/test_activation.py" "pytest_test_backend_reference_activation.xml" \
+        "$PYTHON" -m pytest -s -v --tb=auto "$plugin_root/backend/reference/test_activation.py"
+    run_pytest_step "reference/test_dropout.py" "pytest_test_backend_reference_dropout.xml" \
+        "$PYTHON" -m pytest -s -v --tb=auto "$plugin_root/backend/reference/test_dropout.py"
+    run_pytest_step "reference/test_gemm.py" "pytest_test_backend_reference_gemm.xml" \
+        "$PYTHON" -m pytest -s -v --tb=auto "$plugin_root/backend/reference/test_gemm.py"
+
+    echo "===== END unittest rc=$FAIL $(date '+%F %T') ====="
+}
+
+run_distributed_suite() {
+    echo "===== START distributed $(date '+%F %T') ====="
+    install_base_deps
+
+    run_distributed_step "attention/test_cp_utils.py" "pytest_test_cp_utils.xml" \
+        "$PYTHON" -m pytest -v -s "$TE_PATH/tests/pytorch/attention/test_cp_utils.py"
+
+    echo "===== END distributed rc=$FAIL $(date '+%F %T') ====="
+}
+
+run_onnx_suite() {
+    echo "===== START onnx $(date '+%F %T') ====="
+    install_onnx_deps
+
+    local skip_expr
+    skip_expr="$(join_with_or "${HYGON_ONNX_SKIP_GROUPS[@]}")"
+    skip_expr="not ($skip_expr)"
+    echo "[SKIP] Hygon/DTK ONNX groups: $skip_expr"
+    run_cmd "onnx" "test_onnx_export.py" "test_onnx_export.xml" \
+        env NVTE_UnfusedDPA_Emulate_FP8=1 \
+        "$PYTHON" -m pytest --tb=auto "$TE_PATH/tests/pytorch/test_onnx_export.py" -k "$skip_expr"
+
+    echo "===== END onnx rc=$FAIL $(date '+%F %T') ====="
+}
+
+run_suite() {
+    case "$1" in
+        debug) run_debug_suite ;;
+        unittest) run_unittest_suite ;;
+        distributed) run_distributed_suite ;;
+        onnx) run_onnx_suite ;;
+        -h|--help) usage; exit 0 ;;
+        *)
+            echo "Unknown suite: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+}
+
+if [ "$#" -eq 0 ]; then
+    set -- debug unittest distributed onnx
+fi
+
+for suite in "$@"; do
+    run_suite "$suite"
+done
+
+if [ "$FAIL" -ne 0 ]; then
+    echo "Error in the following test cases: ${FAILED_CASES[*]}"
+    exit 1
+fi
+
+echo "Selected Hygon/DTK reference-baseline tests passed (some optional groups might have been skipped)."

--- a/tests/plugin/backend/hygon/set_env.sh
+++ b/tests/plugin/backend/hygon/set_env.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Hygon/DTK-specific environment for plugin QA workflows.
+# Keep chip/runtime details here so common QA entrypoints do not need
+# Hygon-specific branches.
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../../../.." && pwd)"
+
+if [ -f "${DTK_ENV_SH:-/opt/dtk/env.sh}" ]; then
+    # DTK owns Hygon runtime paths; keep them out of common workflow logic.
+    source "${DTK_ENV_SH:-/opt/dtk/env.sh}"
+fi
+
+export TE_PATH="${TE_PATH:-$REPO_ROOT}"
+export XML_LOG_DIR="${XML_LOG_DIR:-$TE_PATH/logs}"
+export PLATFORM="${PLATFORM:-hygon}"
+export TE_FL_SKIP_CUDA="${TE_FL_SKIP_CUDA:-1}"
+export TE_FL_PREFER="${TE_FL_PREFER:-reference}"
+export NVTE_FRAMEWORK="${NVTE_FRAMEWORK:-pytorch}"
+export PYTHON_BIN="${PYTHON_BIN:-python3}"
+export PYTHONDONTWRITEBYTECODE="${PYTHONDONTWRITEBYTECODE:-1}"
+export PYTHONPATH="$TE_PATH${PYTHONPATH:+:$PYTHONPATH}"
+
+# The current DTK reference/vendor CI path should avoid fused CUDA attention
+# assumptions.
+export NVTE_FLASH_ATTN="${NVTE_FLASH_ATTN:-0}"
+export NVTE_FUSED_ATTN="${NVTE_FUSED_ATTN:-0}"
+export NVTE_UNFUSED_ATTN="${NVTE_UNFUSED_ATTN:-1}"
+
+# ONNX export tests can emulate FP8 attention when no native backend is
+# available.
+export NVTE_UnfusedDPA_Emulate_FP8="${NVTE_UnfusedDPA_Emulate_FP8:-1}"
+
+mkdir -p "$XML_LOG_DIR"

--- a/tests/test_utils/run_ci_test_group.py
+++ b/tests/test_utils/run_ci_test_group.py
@@ -42,8 +42,13 @@ def _run_script(group: dict[str, Any]) -> int:
     if not script_path.is_file():
         raise SystemExit(f"Test script does not exist: {script_path}")
     command = ["bash", str(script_path)]
+    command.extend(_expand(str(arg)) for arg in group.get("args", []))
+    script_env = os.environ.copy()
+    script_env.update(
+        {str(key): _expand(str(value)) for key, value in group.get("env", {}).items()}
+    )
     print(f"[RUN] {shlex.join(command)}", flush=True)
-    return subprocess.run(command, cwd=REPO_ROOT, check=False).returncode
+    return subprocess.run(command, cwd=REPO_ROOT, env=script_env, check=False).returncode
 
 
 def _pytest_command(use_platform_runner: bool) -> list[str]:


### PR DESCRIPTION
## Summary

This PR adds a Hygon BW1000 CI baseline using the TE-FL reference backend and reorganizes the plugin tests into a backend-oriented structure under `tests/plugin`.

The Hygon workflow validates the reference path only. It does not add or claim a native Hygon vendor backend.

## Changes

- Add Hygon CI configuration, environment setup, and workflow entry.
- Add Hygon unit, distributed smoke, ONNX smoke, and MCore integration tests.
- Refactor common workflows to use platform configuration and setup scripts without chip-specific branches.
- Move plugin tests from `transformer_engine/plugin/tests` to:
  - `tests/plugin/plugin`
  - `tests/plugin/backend/reference`
  - `tests/plugin/backend/flagos`
  - `tests/plugin/backend/npu`
  - `tests/plugin/backend/hygon`
- Remove legacy plugin test files that were not collected by pytest.
- Convert the FlagOS fused RoPE tests to standard pytest tests.
- Add documentation for adding and running tests locally.
- Use the unified 8-GPU runner labels.

## Hygon Baseline

- Hardware: Hygon BW1000
- Backend policy: `TE_FL_PREFER=reference`
- GEMM implementation: `reference.torch`
- Runner label: `hg-8g-cicd-te`
- Coverage enabled but not required
- Debug tests are explicitly skipped when `nvdlfw_inspect` is unavailable

## Testing

Validated on Hygon BW1000:

- PyTorch unit tests
- Plugin manager and policy tests
- Reference backend tests
- Distributed smoke tests
- ONNX smoke tests
- Coverage aggregation
- Megatron-LM-FL MCore integration test

All configured Hygon CI jobs passed.
