### PR TITLE
fix(plugin): align reference compute-scale semantics

### DIFF
--- a/.github/workflows/te-plugin-tests.yml
+++ b/.github/workflows/te-plugin-tests.yml
@@ -86,7 +86,7 @@ jobs:
           # install MagicMock modules into sys.modules, so a single pytest process can leak
           # mocked dependencies across files and produce order-dependent failures.
           mapfile -t plugin_tests < <(
-            find tests/plugin/plugin tests/plugin/backend \
+            find tests/plugin/plugin tests/plugin/backend tests/plugin/accuracy \
               -path 'tests/plugin/backend/npu' -prune -o \
               -name 'test_*.py' -type f -print | sort
           )

--- a/tests/plugin/accuracy/__init__.py
+++ b/tests/plugin/accuracy/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-backend accuracy tests for plugin implementations."""

--- a/tests/plugin/accuracy/test_compute_scale.py
+++ b/tests/plugin/accuracy/test_compute_scale.py
@@ -1,0 +1,77 @@
+import itertools
+
+import pytest
+import torch
+
+from transformer_engine import te_device_type
+
+from .utils import available_implementations
+
+
+OP_NAME = "multi_tensor_compute_scale_and_scale_inv"
+
+
+@pytest.mark.parametrize(
+    "amax,epsilon,pow2,expected_scale",
+    [
+        (8.0, 0.0, False, 56.0),
+        (0.5, 1.0, False, 448.0),
+        (0.0, 0.0, False, 1.0),
+        (float("inf"), 0.0, False, 1.0),
+        (float("nan"), 0.0, False, 1.0),
+        (4.0, 0.0, True, 64.0),
+    ],
+)
+@pytest.mark.parametrize("noop", [0, 1])
+def test_compute_scale_matches_cuda_semantics(amax, epsilon, pow2, expected_scale, noop):
+    implementations = available_implementations(OP_NAME)
+    if len(implementations) < 2:
+        pytest.skip(f"{OP_NAME} has fewer than two available implementations")
+
+    device = torch.device(te_device_type())
+    expected = torch.tensor([expected_scale], device=device, dtype=torch.float32)
+    expected_inv = expected.reciprocal()
+    results = {}
+
+    for impl in implementations:
+        amax_tensor = torch.tensor([amax], device=device, dtype=torch.float32)
+        scale = torch.full_like(amax_tensor, -1.0)
+        scale_inv = torch.full_like(amax_tensor, -1.0)
+        impl.fn(
+            2048,
+            torch.tensor([noop], device=device, dtype=torch.int32),
+            [[amax_tensor], [scale], [scale_inv]],
+            448.0,
+            pow2,
+            epsilon,
+        )
+        assert torch.equal(scale, expected), f"{impl.impl_id}: unexpected scale"
+        assert torch.equal(scale_inv, expected_inv), f"{impl.impl_id}: unexpected scale_inv"
+        results[impl.impl_id] = (scale, scale_inv)
+
+    for (left_id, left), (right_id, right) in itertools.combinations(results.items(), 2):
+        for left_tensor, right_tensor in zip(left, right):
+            assert torch.equal(left_tensor, right_tensor), f"{left_id} != {right_id}"
+
+
+def test_compute_scale_saturates_fp32_overflow():
+    implementations = available_implementations(OP_NAME)
+    if len(implementations) < 2:
+        pytest.skip(f"{OP_NAME} has fewer than two available implementations")
+
+    device = torch.device(te_device_type())
+    expected_scale = torch.finfo(torch.float32).max
+    for impl in implementations:
+        amax = torch.tensor([torch.finfo(torch.float32).tiny], device=device)
+        scale = torch.empty_like(amax)
+        scale_inv = torch.empty_like(amax)
+        impl.fn(
+            2048,
+            torch.zeros(1, device=device, dtype=torch.int32),
+            [[amax], [scale], [scale_inv]],
+            448.0,
+            False,
+            0.0,
+        )
+        assert scale.item() == expected_scale, impl.impl_id
+        assert scale_inv.item() == 0.0, impl.impl_id

--- a/tests/plugin/accuracy/utils.py
+++ b/tests/plugin/accuracy/utils.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from transformer_engine.plugin.core import get_manager
+
+
+_IMPLEMENTATION_PREFIXES = ("default.flagos", "reference.torch", "vendor.")
+
+
+def available_implementations(op_name: str):
+    """Return available FlagOS, Reference, and current-vendor implementations."""
+    manager = get_manager()
+    manager.ensure_initialized()
+    implementations = [
+        impl
+        for impl in manager.registry.get_implementations(op_name)
+        if impl.impl_id.startswith(_IMPLEMENTATION_PREFIXES) and impl.is_available()
+    ]
+    return sorted(implementations, key=lambda impl: impl.impl_id)

--- a/tests/plugin/backend/reference/test_compute_scale.py
+++ b/tests/plugin/backend/reference/test_compute_scale.py
@@ -1,0 +1,50 @@
+import pytest
+import torch
+
+from transformer_engine.plugin.core.backends.reference.impl.optimizer import (
+    multi_tensor_compute_scale_and_scale_inv_torch,
+)
+
+
+@pytest.mark.parametrize(
+    "amax,epsilon,pow2,expected_scale",
+    [
+        (8.0, 0.0, False, 56.0),
+        (0.5, 1.0, False, 448.0),
+        (0.0, 0.0, False, 1.0),
+        (float("inf"), 0.0, False, 1.0),
+        (float("nan"), 0.0, False, 1.0),
+        (4.0, 0.0, True, 64.0),
+    ],
+)
+def test_compute_scale_and_scale_inv_matches_cuda_edges(amax, epsilon, pow2, expected_scale):
+    amax_tensor = torch.tensor([amax], dtype=torch.float32)
+    scale = torch.full((1,), -1.0)
+    scale_inv = torch.full((1,), -1.0)
+    multi_tensor_compute_scale_and_scale_inv_torch(
+        2048,
+        torch.ones(1, dtype=torch.int32),
+        [[amax_tensor], [scale], [scale_inv]],
+        448.0,
+        pow2,
+        epsilon,
+    )
+    expected = torch.tensor([expected_scale], dtype=torch.float32)
+    assert torch.equal(scale, expected)
+    assert torch.equal(scale_inv, expected.reciprocal())
+
+
+def test_compute_scale_saturates_fp32_overflow_like_cuda():
+    amax = torch.tensor([torch.finfo(torch.float32).tiny])
+    scale = torch.empty_like(amax)
+    scale_inv = torch.empty_like(amax)
+    multi_tensor_compute_scale_and_scale_inv_torch(
+        2048,
+        torch.zeros(1, dtype=torch.int32),
+        [[amax], [scale], [scale_inv]],
+        448.0,
+        False,
+        0.0,
+    )
+    assert scale.item() == torch.finfo(torch.float32).max
+    assert scale_inv.item() == 0.0

--- a/transformer_engine/plugin/core/backends/reference/impl/optimizer.py
+++ b/transformer_engine/plugin/core/backends/reference/impl/optimizer.py
@@ -361,15 +361,14 @@ def multi_tensor_compute_scale_and_scale_inv_torch(
 
     Args:
         chunk_size: Chunk size (unused in PyTorch implementation)
-        noop_flag: If non-zero, skip computation
+        noop_flag: Ignored to match the TEX CUDA kernel
         tensor_lists: [amaxes, scales, scale_invs]
         max_fp8: Maximum representable value in FP8 format (e.g., 448.0 for E4M3)
         force_pow_2_scales: If True, force scales to be powers of 2
-        amax_epsilon: Small epsilon to add to amax to avoid division by zero
+        amax_epsilon: Lower bound applied to amax before scale computation
     """
-    if noop_flag.item() != 0:
-        return
-
+    # TEX intentionally ignores noop_flag for this kernel so NaN/Inf amax
+    # values still flow through the scale update path.
     if len(tensor_lists) != 3:
         raise ValueError("tensor_lists should contain [amaxes, scales, scale_invs]")
 
@@ -379,23 +378,36 @@ def multi_tensor_compute_scale_and_scale_inv_torch(
         raise ValueError("All tensor lists must have the same length")
 
     for amax, scale, scale_inv in zip(amaxes, scales, scale_invs):
-        # Add epsilon to avoid division by zero
-        amax_val = amax + amax_epsilon
+        # Match compute_scale_from_amax in recipe_common.cuh. CUDA computes
+        # this kernel in float regardless of the storage tensor wrappers.
+        amax_val = amax.float()
+        epsilon = torch.as_tensor(amax_epsilon, dtype=torch.float32, device=amax.device)
+        amax_val = torch.where(amax_val < epsilon, epsilon, amax_val)
 
-        # Compute scale: max_fp8 / amax
-        # Clamp amax to avoid very small values
-        amax_val = torch.clamp(amax_val, min=1e-12)
+        invalid = torch.isinf(amax_val) | torch.isnan(amax_val) | (amax_val == 0)
         computed_scale = max_fp8 / amax_val
+        computed_scale = torch.where(
+            torch.isinf(computed_scale),
+            torch.full_like(computed_scale, torch.finfo(torch.float32).max),
+            computed_scale,
+        )
+        computed_scale = torch.where(invalid, torch.ones_like(computed_scale), computed_scale)
 
         if force_pow_2_scales:
-            # Round scale to nearest power of 2
-            log2_scale = torch.log2(computed_scale)
-            log2_scale = torch.round(log2_scale)
-            computed_scale = torch.pow(2.0, log2_scale)
+            # CUDA clears all mantissa bits, i.e. rounds down to a power of 2.
+            scale_bits = computed_scale.contiguous().view(torch.int32)
+            computed_scale = torch.bitwise_and(scale_bits, -8388608).view(torch.float32)
 
-        # Update scale and scale_inv
-        scale.copy_(computed_scale)
-        scale_inv.copy_(1.0 / computed_scale)
+        computed_scale_inv = computed_scale.reciprocal()
+        # CUDA's __frcp_rn runs with FTZ semantics, so subnormal reciprocals
+        # (e.g. 1 / FLT_MAX) are written as zero.
+        computed_scale_inv = torch.where(
+            computed_scale_inv.abs() < torch.finfo(torch.float32).tiny,
+            torch.zeros_like(computed_scale_inv),
+            computed_scale_inv,
+        )
+        scale.copy_(computed_scale.to(scale.dtype))
+        scale_inv.copy_(computed_scale_inv.to(scale_inv.dtype))
 
 
 def multi_tensor_compute_scale_inv_e8m0_torch(


### PR DESCRIPTION
# Description

 Align the Reference backend implementation of `multi_tensor_compute_scale_and_scale_inv` with TransformerEngine’s CUDA semantics, and add a lightweight cross-backend accuracy check.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Update `multi_tensor_compute_scale_and_scale_inv` to match the TEX CUDA implementation:

  - Treat `amax_epsilon` as a lower bound instead of adding it to `amax`.
  - Ignore `noop_flag`, consistent with the CUDA kernel.
  - Return a scale of `1` for zero, NaN, and Inf `amax` values.
  - Saturate FP32 scale overflow to `torch.finfo(torch.float32).max`.
  - Compute forced power-of-two scales by clearing mantissa bits, which rounds
    down to a power of two.
  - Emulate CUDA FTZ behavior for subnormal reciprocal values.
  - Perform scale computation in FP32 before copying results to output tensors.
