### PR TITLE
把multi_tensor_scale_tensor接入到TE-NPU

### DIFF
--- a/transformer_engine/plugin/core/backends/vendor/npu/npu.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/npu.py
@@ -222,6 +222,22 @@ class NPUBackend(TEFLBackendBase):
         opt = _get_tenpu_optimizers()
         opt.multi_tensor_scale(chunk_size, noop_flag, tensor_lists, scale)
 
+    def multi_tensor_scale_tensor(
+        self,
+        chunk_size: int,
+        noop_flag: torch.Tensor,
+        tensor_lists: List[List[torch.Tensor]],
+        scale: torch.Tensor,
+) -> None:
+        """Multi-tensor scale with a tensor-valued scale factor."""
+        opt = _get_tenpu_optimizers()
+        return opt.multi_tensor_scale_tensor(
+            chunk_size,
+            noop_flag,
+            tensor_lists,
+            scale,
+    )
+
     def multi_tensor_l2norm(
         self,
         chunk_size: int,

--- a/transformer_engine/plugin/core/backends/vendor/npu/register_ops.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/register_ops.py
@@ -80,6 +80,15 @@ def register_builtins(registry) -> None:
             vendor="NPU",
             priority=100,
         ),
+        # Multi-tensor scale with tensor
+        OpImpl(
+            op_name="multi_tensor_scale_tensor",
+            impl_id="vendor.npu",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.multi_tensor_scale_tensor, is_avail),
+            vendor="NPU",
+            priority=100,
+        ),
         # Multi-tensor L2 norm
         OpImpl(
             op_name="multi_tensor_l2norm",


### PR DESCRIPTION
### 问题

TE-FL 公共 ABI 定义了 multi_tensor_scale_tensor，而 TransformerEngineNPU 提供了相同的优化器实现。  
然而，TE-FL NPU 后端没有适配器方法，也没有注册条目，因此 OpManager 无法为该操作选择 vendor.npu。

### 修改内容

- 添加 NPUBackend.multi_tensor_scale_tensor() 方法。
- 将调用转发至 TENPU 中同名的优化器。
- 将此操作注册为 vendor.npu。
- 增加针对缩放操作和非无穷标志传播的 NPU 功能测试。

### 范围

此补丁将现有的 TENPU 实现进行连接。内部 scale.item() 的转换保持不变。