### PR TITLE
[NPU] Add Gated Delta Net forward and backward support

### DIFF
--- a/transformer_engine/plugin/core/backends/vendor/npu/gated_delta_net.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/gated_delta_net.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2025, BAAI. All rights reserved.
+# Copyright (c) 2026, Huawei Technologies Co., Ltd. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Gated Delta Net implementation backed by local GDN implementation."""
+
+from __future__ import annotations
+
+import logging
+from types import NotImplementedType
+from typing import Optional, Tuple
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def is_gated_delta_net_available() -> bool:
+    """Check required Python operators and NPU availability, without launching kernels."""
+    try:
+        from .gdn_operators import validate_runtime
+
+        validate_runtime()
+        return hasattr(torch, "npu") and torch.npu.is_available()
+    except (ImportError, RuntimeError, OSError) as e:
+        logger.warning(f"[GDN] Runtime validation failed: {e}")
+        return False
+
+
+def gated_delta_net_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    use_qk_l2norm: bool = False,
+    chunk_size: int = 64,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]] | NotImplementedType:
+    """Run GDN while preserving the TE-FL BSHD contract.
+
+    TE-FL receives ``query``, ``key`` and ``value`` in BSHD layout. The GDN
+    implementation expects BHSD layout and returns output in BSHD layout.
+    ``g`` and ``beta`` remain BSH tensors.
+
+    Return NotImplemented before kernel execution for unsupported inputs or
+    missing optional dependencies. The caller owns native fallback; a cached
+    callable rechecks this contract on every call. Invalid inputs and kernel
+    execution errors raise normally, never becoming fallback results.
+    """
+    _validate_inputs(query, key, value, g, beta, initial_state, chunk_size)
+    if (
+        query.device.type != "npu"
+        or query.dtype not in (torch.float16, torch.bfloat16)
+        or any(size == 0 for size in query.shape[:3])
+        or query.shape[-1] != 128
+        or value.shape[-1] != 128
+        or beta.dtype != query.dtype
+        or g.dtype != torch.float32
+        or chunk_size != 64
+        or initial_state is not None
+        or output_final_state
+    ):
+        return NotImplemented
+    if not is_gated_delta_net_available():
+        return NotImplemented
+
+    from .gdn_impl import flash_gated_delta_rule
+
+    # Call implementation with layout conversion BSHD -> BHSD
+    output, final_state = flash_gated_delta_rule(
+        q=query.transpose(1, 2).contiguous(),
+        k=key.transpose(1, 2).contiguous(),
+        v=value.transpose(1, 2).contiguous(),
+        g=g.contiguous(),
+        beta=beta.contiguous(),
+        scale=None,  # Will be computed inside
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm,
+        chunk_size=chunk_size,
+    )
+
+    return output.contiguous(), final_state
+
+
+def _validate_inputs(query, key, value, g, beta, initial_state, chunk_size):
+    if type(chunk_size) is not int or chunk_size <= 0 or chunk_size & (chunk_size - 1):
+        raise ValueError("chunk_size must be a positive power of two.")
+    if query.ndim != 4 or key.shape != query.shape or value.ndim != 4:
+        raise ValueError("query/key must match and query/key/value must be BSHD tensors.")
+    if value.shape[:3] != query.shape[:3] or g.shape != query.shape[:3] or beta.shape != g.shape:
+        raise ValueError("query/key/value/g/beta must have matching BSH dimensions.")
+    if query.shape[-1] == 0 or value.shape[-1] == 0:
+        raise ValueError("Head dimensions must be positive.")
+    tensors = (query, key, value, g, beta)
+    if any(t.device != query.device or not t.is_floating_point() for t in tensors):
+        raise ValueError("All inputs must be floating point tensors on the same device.")
+    if key.dtype != query.dtype or value.dtype != query.dtype:
+        raise ValueError("query/key/value must have the same dtype.")
+    if initial_state is not None:
+        expected = (query.shape[0], query.shape[2], query.shape[3], value.shape[3])
+        if initial_state.shape != expected or initial_state.device != query.device:
+            raise ValueError("initial_state must be BHKV on the input device.")
+        if not initial_state.is_floating_point():
+            raise ValueError("initial_state must be floating point.")

--- a/transformer_engine/plugin/core/backends/vendor/npu/gdn_impl.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/gdn_impl.py
@@ -1,0 +1,507 @@
+# Copyright (c) 2025, BAAI. All rights reserved.
+# Copyright (c) 2026, Huawei Technologies Co., Ltd. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""GDN implementation with complete forward and backward passes using fla_npu operators.
+
+This module implements the complete Gated Delta Net algorithm using fine-grained
+AscendC and Triton operators from fla_npu.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional, Tuple
+
+import torch
+
+from fla_npu.ops.ascendc import (
+    chunk_bwd_dqkwg as ascendc_chunk_bwd_dqkwg,
+    chunk_bwd_dv_local as ascendc_chunk_bwd_dv_local,
+    chunk_fwd_o as ascendc_chunk_fwd_o,
+    chunk_gated_delta_rule_bwd_dhu as ascendc_chunk_gated_delta_rule_bwd_dhu,
+    chunk_gated_delta_rule_fwd_h as ascendc_chunk_gated_delta_rule_fwd_h,
+    prepare_wy_repr_bwd_da as ascendc_prepare_wy_repr_bwd_da,
+    prepare_wy_repr_bwd_full as ascendc_prepare_wy_repr_bwd_full,
+    recompute_w_u_fwd as ascendc_recompute_w_u_fwd,
+    solve_tri as ascendc_solve_tri,
+)
+from fla_npu.ops.triton import (
+    autocast_custom_bwd,
+    autocast_custom_fwd,
+    chunk_local_cumsum,
+    chunk_scaled_dot_kkt_fwd,
+    input_guard,
+    l2norm_bwd,
+    l2norm_fwd,
+    solve_tril_npu,
+)
+
+
+def _as_int_list(value: Optional[torch.Tensor]) -> Optional[list]:
+    """Convert tensor to list of integers."""
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        return [int(x) for x in value.detach().cpu().flatten().tolist()]
+    return [int(x) for x in value]
+
+
+def _chunk_list(chunk_indices_list: Optional[Dict], chunk_size: int) -> Optional[list]:
+    """Get chunk indices list for specific chunk size."""
+    if chunk_indices_list is None:
+        return None
+    return chunk_indices_list.get(str(chunk_size))
+
+
+def _chunk_tensor(chunk_indices: Optional[Dict], chunk_size: int) -> Optional[torch.Tensor]:
+    """Get chunk indices tensor for specific chunk size."""
+    if chunk_indices is None:
+        return None
+    return chunk_indices.get(str(chunk_size))
+
+
+def solve_tri_ascendc(
+    A: torch.Tensor,
+    cu_seqlens: Optional[list] = None,
+    chunk_indices: Optional[list] = None,
+    output_dtype: torch.dtype = torch.float,
+) -> torch.Tensor:
+    """Solve triangular system using AscendC."""
+    A_in = A.to(output_dtype).contiguous()
+
+    if cu_seqlens is None:
+        # Standard batch mode
+        return ascendc_solve_tri(A_in, layout="bsnd")
+
+    # Varlen mode
+    if A_in.ndim != 4 or A_in.shape[0] != 1:
+        raise ValueError(
+            f"solve_tri varlen expects A with shape [1, T, H, BT], got {tuple(A_in.shape)}"
+        )
+    if chunk_indices is None:
+        raise ValueError("solve_tri varlen requires chunk_indices")
+
+    out = ascendc_solve_tri(
+        A_in.squeeze(0),
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        layout="tnd",
+    )
+    return out.unsqueeze(0)
+
+
+def solve_tri(
+    A: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor],
+    chunk_indices: Optional[Dict],
+    cu_seqlens_list: Optional[list],
+    chunk_indices_list: Optional[list],
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Solve triangular system with backend selection."""
+    backend = os.getenv("FLA_NPU_GDN_SOLVE_TRI_BACKEND", "ascendc").strip().lower()
+
+    if backend == "ascendc":
+        return solve_tri_ascendc(
+            A,
+            cu_seqlens=cu_seqlens_list,
+            chunk_indices=chunk_indices_list,
+            output_dtype=output_dtype,
+        )
+    elif backend == "triton":
+        return solve_tril_npu(
+            A=A,
+            cu_seqlens=cu_seqlens,
+            chunk_indices_out=chunk_indices,
+            output_dtype=output_dtype,
+        )
+    else:
+        raise ValueError(
+            f"FLA_NPU_GDN_SOLVE_TRI_BACKEND must be 'ascendc' or 'triton', got {backend!r}"
+        )
+
+
+def recompute_w_u(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    g: torch.Tensor,
+    chunk_size: int,
+    cu_seqlens: Optional[list],
+    chunk_indices: Optional[list],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Recompute W and U from K, V, beta, A."""
+    w, u = ascendc_recompute_w_u_fwd(
+        k, v, beta, A, chunk_size,
+        g=g,
+        gk=None,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    return w, u
+
+
+def flash_chunk_gated_delta_rule_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: Optional[torch.Tensor],
+    output_final_state: bool,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    cu_seqlens_list: Optional[list] = None,
+    chunk_indices: Optional[Dict] = None,
+    chunk_indices_list: Optional[Dict] = None,
+    chunk_size: int = 64,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """Forward pass: 6 steps."""
+
+    # Step 1: Compute cumulative sum of g
+    g = chunk_local_cumsum(
+        g,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices_out=chunk_indices,
+        head_first=False,
+    )
+
+    # Step 2: Compute A = K^T @ K (scaled with decay)
+    A = chunk_scaled_dot_kkt_fwd(
+        k=k,
+        g=g,
+        beta=beta,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=_chunk_tensor(chunk_indices, chunk_size),
+        chunk_size=chunk_size,
+        output_dtype=torch.float32,
+    )
+
+    # Step 3: Solve triangular system
+    A = solve_tri(
+        A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        cu_seqlens_list=cu_seqlens_list,
+        chunk_indices_list=_chunk_list(chunk_indices_list, chunk_size),
+        output_dtype=k.dtype,
+    )
+
+    # Transpose for AscendC operators
+    g = g.transpose(1, 2).contiguous()
+    beta = beta.transpose(1, 2).contiguous().float()
+    A = A.transpose(1, 2).contiguous()
+
+    # Step 4: Recompute W and U
+    w, u = recompute_w_u(
+        k, v, beta, A, g,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    # Step 5: Compute recurrent state H
+    h, v_new, final_state = ascendc_chunk_gated_delta_rule_fwd_h(
+        k, w, u,
+        g=g,
+        gk=None,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    if not output_final_state:
+        final_state = None
+
+    # Step 6: Compute output O
+    o = ascendc_chunk_fwd_o(
+        q, k, v_new, h, scale,
+        g=g,
+        g_gamma=None,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        chunk_size=chunk_size,
+        transpose_state_layout=False,
+    )
+
+    # Transpose back
+    g = g.transpose(1, 2).contiguous()
+    o = o.transpose(1, 2).contiguous()
+
+    return g, o, A, final_state
+
+
+def flash_chunk_gated_delta_rule_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    scale: float,
+    initial_state: Optional[torch.Tensor],
+    do: torch.Tensor,
+    dht: Optional[torch.Tensor],
+    cu_seqlens: Optional[torch.Tensor] = None,
+    cu_seqlens_list: Optional[list] = None,
+    chunk_indices: Optional[Dict] = None,
+    chunk_indices_list: Optional[Dict] = None,
+    chunk_size: int = 64,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """Backward pass: 6 steps."""
+
+    # Transpose for AscendC operators
+    g = g.transpose(1, 2).contiguous()
+    beta = beta.transpose(1, 2).contiguous().float()
+
+    # Recompute W and U
+    w, u = recompute_w_u(
+        k, v, beta, A, g,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    do = do.transpose(1, 2).contiguous()
+
+    # Recompute forward intermediate values
+    h, v_new, _ = ascendc_chunk_gated_delta_rule_fwd_h(
+        k, w, u,
+        g=g,
+        gk=None,
+        initial_state=initial_state,
+        output_final_state=False,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    # Step 1: Compute dV (local)
+    dv = ascendc_chunk_bwd_dv_local(
+        q, k, do, g, scale, chunk_size,
+        g_gamma=None,
+        A=A,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    # Step 2: Compute dH and update dV
+    dh, dh0, dv = ascendc_chunk_gated_delta_rule_bwd_dhu(
+        q, k, w, do, dv, scale, chunk_size,
+        g=g,
+        gK=None,
+        h0=None,
+        dht=None,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        use_exp2=False,
+        transpose_state_layout=False,
+    )
+    dh0 = None
+
+    # Step 3: Compute dQ, dK, dW, dG
+    dq, dk, dw, dg = ascendc_chunk_bwd_dqkwg(
+        q, k, v_new, g, h, do, dh, dv, chunk_size,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+        w=None,
+        g_gamma=None,
+        scale=scale,
+        use_exp2=False,
+        transpose_state_layout=False,
+    )
+
+    # Step 4: Compute dA
+    dA = ascendc_prepare_wy_repr_bwd_da(
+        k, v, beta.float(), A, dw, dv, g.float(),
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    # Step 5: Full WY representation backward
+    dk2, dv, db, dg2 = ascendc_prepare_wy_repr_bwd_full(
+        k, v, beta, A, dA, dw, dv, g, chunk_size,
+        cu_seqlens=cu_seqlens_list,
+        chunk_indices=_chunk_list(chunk_indices_list, chunk_size),
+    )
+
+    # Transpose gradients back
+    db = db.transpose(1, 2).contiguous()
+    dg2 = dg2.transpose(1, 2).contiguous()
+    dg = dg.transpose(1, 2).contiguous()
+
+    # Accumulate gradients
+    dk.add_(dk2)
+    dg.add_(dg2)
+
+    # Step 6: Reverse cumsum for dG
+    dg = chunk_local_cumsum(
+        dg,
+        chunk_size=chunk_size,
+        reverse=True,
+        cu_seqlens=cu_seqlens,
+        chunk_indices_out=chunk_indices,
+        head_first=False,
+    )
+
+    return dq, dk, dv, db, dg, dh0
+
+
+class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
+    """Autograd function for GDN with complete forward/backward."""
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_fwd
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        scale: float,
+        initial_state: Optional[torch.Tensor],
+        output_final_state: bool,
+        cu_seqlens: Optional[torch.Tensor] = None,
+        cu_seqlens_list: Optional[list] = None,
+        chunk_indices: Optional[Dict] = None,
+        chunk_indices_list: Optional[Dict] = None,
+        use_qk_l2norm_in_kernel: bool = False,
+        chunk_size: int = 64,
+    ):
+        # Apply L2 normalization if requested
+        if use_qk_l2norm_in_kernel:
+            q, q_rstd = l2norm_fwd(q)
+            k, k_rstd = l2norm_fwd(k)
+        else:
+            q_rstd, k_rstd = None, None
+
+        # Forward pass
+        g, o, A, final_state = flash_chunk_gated_delta_rule_fwd(
+            q=q, k=k, v=v, g=g, beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_list=cu_seqlens_list,
+            chunk_indices=chunk_indices,
+            chunk_indices_list=chunk_indices_list,
+            chunk_size=chunk_size,
+        )
+
+        # Save for backward
+        ctx.save_for_backward(q, k, v, g, beta, A)
+        ctx.q_rstd = q_rstd
+        ctx.k_rstd = k_rstd
+        ctx.initial_state = initial_state
+        ctx.cu_seqlens = cu_seqlens
+        ctx.scale = scale
+        ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
+        ctx.chunk_size = chunk_size
+        ctx.cu_seqlens_list = cu_seqlens_list
+        ctx.chunk_indices = chunk_indices
+        ctx.chunk_indices_list = chunk_indices_list
+
+        return o.to(q.dtype), final_state
+
+    @staticmethod
+    @input_guard
+    @autocast_custom_bwd
+    def backward(ctx, do: torch.Tensor, dht: Optional[torch.Tensor]):
+        q, k, v, g, beta, A = ctx.saved_tensors
+
+        # Backward pass
+        dq, dk, dv, db, dg, dh0 = flash_chunk_gated_delta_rule_bwd(
+            q=q, k=k, v=v, g=g, beta=beta, A=A,
+            scale=ctx.scale,
+            initial_state=ctx.initial_state,
+            do=do,
+            dht=dht,
+            cu_seqlens=ctx.cu_seqlens,
+            cu_seqlens_list=ctx.cu_seqlens_list,
+            chunk_indices=ctx.chunk_indices,
+            chunk_indices_list=ctx.chunk_indices_list,
+            chunk_size=ctx.chunk_size,
+        )
+
+        # Apply L2 norm backward if used in forward
+        if ctx.use_qk_l2norm_in_kernel:
+            dq = l2norm_bwd(q, ctx.q_rstd, dq)
+            dk = l2norm_bwd(k, ctx.k_rstd, dk)
+
+        return (
+            dq.to(q.dtype),
+            dk.to(k.dtype),
+            dv.to(v.dtype),
+            dg.to(g.dtype),
+            db.to(beta.dtype),
+            None,  # scale
+            dh0,   # initial_state
+            None,  # output_final_state
+            None,  # cu_seqlens
+            None,  # cu_seqlens_list
+            None,  # chunk_indices
+            None,  # chunk_indices_list
+            None,  # use_qk_l2norm_in_kernel
+            None,  # chunk_size
+        )
+
+
+def flash_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    cu_seqlens_list: Optional[list] = None,
+    chunk_indices: Optional[Dict] = None,
+    chunk_indices_list: Optional[Dict] = None,
+    chunk_size: int = 64,
+    head_first: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Main entry point for GDN.
+
+    Expects BHSD layout for q, k, v and BSH for g, beta.
+    Returns output in BSHD layout.
+    """
+    # Input validation
+    if q.dtype != k.dtype or k.dtype != v.dtype:
+        raise ValueError("q, k, v must have the same dtype")
+    if q.dtype == torch.float32:
+        raise ValueError("GDN does not support float32, use float16/bfloat16")
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        raise ValueError("q, k, v must be rank-4 [B, H, T, D] tensors")
+    if g.ndim != 3 or beta.ndim != 3:
+        raise ValueError("g, beta must be rank-3 [B, T, H] tensors")
+
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    # Call autograd function
+    o, final_state = ChunkGatedDeltaRuleFunction.apply(
+        q, k, v, g, beta,
+        float(scale),
+        initial_state,
+        output_final_state,
+        cu_seqlens,
+        cu_seqlens_list,
+        chunk_indices,
+        chunk_indices_list,
+        use_qk_l2norm_in_kernel,
+        chunk_size,
+    )
+
+    return o, final_state

--- a/transformer_engine/plugin/core/backends/vendor/npu/gdn_operators.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/gdn_operators.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2025, BAAI. All rights reserved.
+# Copyright (c) 2026, Huawei Technologies Co., Ltd. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""AscendC operator wrappers and runtime validation for GDN."""
+
+from __future__ import annotations
+
+# API version for compatibility checking
+GDN_API_VERSION = 1
+GDN_PROVIDER = "te_npu_vendor"
+
+# Required AscendC operators for complete GDN implementation
+_REQUIRED_ASCENDC_OPS = (
+    "chunk_fwd_o",
+    "chunk_gated_delta_rule_fwd_h",
+    "chunk_gated_delta_rule_bwd_dhu",
+    "chunk_bwd_dqkwg",
+    "chunk_bwd_dv_local",
+    "prepare_wy_repr_bwd_da",
+    "prepare_wy_repr_bwd_full",
+    "recompute_w_u_fwd",
+    "solve_tri",
+)
+
+
+def validate_runtime() -> dict:
+    """Validate that all required operators are loaded.
+
+    Returns:
+        dict: Runtime information including API version and provider
+
+    Raises:
+        RuntimeError: If any required operators are missing
+    """
+    try:
+        import fla_npu.ops.ascendc as ascendc
+    except ImportError as e:
+        raise RuntimeError(f"fla_npu.ops.ascendc not available: {e}") from e
+
+    missing = []
+    for op_name in _REQUIRED_ASCENDC_OPS:
+        if not callable(getattr(ascendc, op_name, None)):
+            missing.append(op_name)
+
+    if missing:
+        raise RuntimeError(
+            f"GDN runtime incomplete, missing operators in fla_npu.ops.ascendc: {', '.join(missing)}\n"
+            f"Please ensure fla_npu is properly installed with all GDN operators."
+        )
+
+    import fla_npu.ops.triton as triton
+
+    required_triton = (
+        "autocast_custom_bwd",
+        "autocast_custom_fwd",
+        "chunk_local_cumsum",
+        "chunk_scaled_dot_kkt_fwd",
+        "input_guard",
+        "l2norm_bwd",
+        "l2norm_fwd",
+        "solve_tril_npu",
+    )
+    missing = [name for name in required_triton if not callable(getattr(triton, name, None))]
+    if missing:
+        raise RuntimeError(f"GDN runtime incomplete, missing Triton operators: {missing}")
+
+    return {
+        "api_version": GDN_API_VERSION,
+        "provider": GDN_PROVIDER,
+        "operators": list(_REQUIRED_ASCENDC_OPS),
+    }

--- a/transformer_engine/plugin/core/backends/vendor/npu/npu.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/npu.py
@@ -731,3 +731,16 @@ class NPUBackend(TEFLBackendBase):
 
         _ = math_sm_count  # CUDA-only tuning knob.
         return bias
+
+    def gated_delta_net_forward(
+        self, query, key, value, g, beta, initial_state=None,
+        output_final_state=False, use_qk_l2norm=False, chunk_size=64,
+    ):
+        """Return GDN output/state, or NotImplemented for caller-owned fallback."""
+        from .gated_delta_net import gated_delta_net_forward
+
+        return gated_delta_net_forward(
+            query, key, value, g, beta, initial_state=initial_state,
+            output_final_state=output_final_state, use_qk_l2norm=use_qk_l2norm,
+            chunk_size=chunk_size,
+        )

--- a/transformer_engine/plugin/core/backends/vendor/npu/register_ops.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/register_ops.py
@@ -44,6 +44,15 @@ def register_builtins(registry) -> None:
     is_avail = backend.is_available
 
     impls = [
+        OpImpl(
+            op_name="gated_delta_net_forward",
+            impl_id="vendor.npu.gdn_fwd",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.gated_delta_net_forward, is_avail),
+            vendor="NPU",
+            priority=100,
+        ),
+
         # FlashAttention class getter
         OpImpl(
             op_name="get_flash_attention_class",

--- a/transformer_engine/plugin/core/backends/vendor/npu/test_gdn.py
+++ b/transformer_engine/plugin/core/backends/vendor/npu/test_gdn.py
@@ -1,0 +1,194 @@
+"""NPU adapter contract and real-kernel parity. CPU mocks are not device evidence."""
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from transformer_engine.plugin.core.backends.vendor.npu import gated_delta_net as vendor
+from transformer_engine.plugin.core.manager import OpManager
+
+
+def tensors(seq=3, dtype=torch.bfloat16):
+    q, k, v = [torch.randn(1, seq, 2, 128, dtype=dtype) * 0.05 for _ in range(3)]
+    return [q, k, v, -torch.rand(1, seq, 2), torch.rand(1, seq, 2).to(dtype)]
+
+
+class MetadataNPU:
+    """CPU payload with simulated device metadata; no kernels are launched."""
+    device = SimpleNamespace(type='npu')
+
+    def __init__(self, tensor):
+        self.tensor = tensor
+
+    def __getattr__(self, name):
+        return getattr(self.tensor, name)
+
+
+def simulated(xs):
+    return [MetadataNPU(x) for x in xs]
+
+
+def test_registration_without_fla_import(monkeypatch):
+    from transformer_engine.plugin.core.backends.vendor.npu.npu import NPUBackend
+    from transformer_engine.plugin.core.backends.vendor.npu.register_ops import register_builtins
+
+    monkeypatch.setattr(NPUBackend, 'is_available', lambda self: True)
+    probe = Mock(side_effect=AssertionError('Registration must not probe FLA'))
+    monkeypatch.setattr(vendor, 'is_gated_delta_net_available', probe)
+    registry = Mock()
+    register_builtins(registry)
+    impls = registry.register_many.call_args.args[0]
+    gdn = [i for i in impls if i.op_name == 'gated_delta_net_forward']
+    assert len(gdn) == 1 and gdn[0].is_available()
+    probe.assert_not_called()
+
+
+def test_availability_runs_validator(monkeypatch):
+    from transformer_engine.plugin.core.backends.vendor.npu import gdn_operators
+
+    probe = Mock(side_effect=RuntimeError('missing operator'))
+    monkeypatch.setattr(gdn_operators, 'validate_runtime', probe)
+    assert not vendor.is_gated_delta_net_available()
+    probe.assert_called_once()
+
+
+@pytest.mark.parametrize('chunk', [0, -1, 3, 1.5, True])
+def test_bad_chunk_is_error(chunk):
+    with pytest.raises(ValueError, match='positive power'):
+        vendor.gated_delta_net_forward(*tensors(), chunk_size=chunk)
+
+
+def test_bad_shape_is_error():
+    xs = tensors()
+    xs[2] = xs[2][:, :1]
+    with pytest.raises(ValueError, match='matching BSH'):
+        vendor.gated_delta_net_forward(*xs)
+
+
+@pytest.mark.parametrize('case', ['cpu', 'fp32', 'empty', 'dimension', 'beta', 'g', 'chunk', 'state', 'final'])
+def test_unsupported_declines_before_runtime(monkeypatch, case):
+    xs = tensors()
+    kw = {}
+    if case == 'fp32':
+        xs[:3] = [x.float() for x in xs[:3]]
+    elif case == 'empty':
+        xs = [x[:, :0] for x in xs]
+    elif case == 'dimension':
+        xs[2] = xs[2][..., :64]
+    elif case == 'beta':
+        xs[4] = xs[4].float()
+    elif case == 'g':
+        xs[3] = xs[3].to(torch.bfloat16)
+    elif case == 'chunk':
+        kw['chunk_size'] = 32
+    elif case == 'state':
+        kw['initial_state'] = MetadataNPU(torch.zeros(1, 2, 128, 128))
+    elif case == 'final':
+        kw['output_final_state'] = True
+    probe = Mock(side_effect=AssertionError('Unsupported inputs must not load FLA'))
+    monkeypatch.setattr(vendor, 'is_gated_delta_net_available', probe)
+    assert vendor.gated_delta_net_forward(*(xs if case == 'cpu' else simulated(xs)), **kw) is NotImplemented
+    probe.assert_not_called()
+
+
+@pytest.mark.parametrize('strict', ['0', '1'])
+@pytest.mark.parametrize('entry', ['call', 'resolve'])
+def test_cached_callable_rechecks_and_recovers(monkeypatch, strict, entry):
+    from transformer_engine.plugin.core.backends.vendor.npu.npu import NPUBackend
+    monkeypatch.setattr(NPUBackend, 'is_available', lambda self: True)
+    monkeypatch.setenv('TE_FL_STRICT', strict)
+    monkeypatch.setenv('TE_FL_PER_OP', 'gated_delta_net_forward=impl:vendor.npu.gdn_fwd')
+    ready = [False]
+    monkeypatch.setattr(vendor, 'is_gated_delta_net_available', lambda: ready[0])
+    kernel = Mock(side_effect=lambda **kw: (kw['v'].transpose(1, 2), None))
+    monkeypatch.setitem(sys.modules, vendor.__package__ + '.gdn_impl', SimpleNamespace(flash_gated_delta_rule=kernel))
+    manager = OpManager()
+    invoke = (lambda *a, **kw: manager.call('gated_delta_net_forward', *a, **kw)) if entry == 'call' else manager.resolve('gated_delta_net_forward')
+    xs = tensors()
+    assert invoke(*simulated(xs)) is NotImplemented
+    ready[0] = True
+    out, _ = invoke(*simulated(xs))
+    torch.testing.assert_close(out, xs[2])
+    assert invoke(*simulated(xs), output_final_state=True) is NotImplemented
+    invoke(*simulated(xs))
+    ready[0] = False
+    assert invoke(*simulated(xs)) is NotImplemented
+    ready[0] = True
+    invoke(*simulated(xs))
+    assert kernel.call_count == 3
+    assert manager.get_selected_impl_id('gated_delta_net_forward') == 'vendor.npu.gdn_fwd'
+
+
+@pytest.mark.parametrize('strict', ['0', '1'])
+@pytest.mark.parametrize('cached', [False, True])
+@pytest.mark.parametrize('error', [ValueError, RuntimeError, torch.OutOfMemoryError])
+def test_kernel_errors_never_become_decline(monkeypatch, strict, cached, error):
+    from transformer_engine.plugin.core.backends.vendor.npu.npu import NPUBackend
+    monkeypatch.setattr(NPUBackend, 'is_available', lambda self: True)
+    monkeypatch.setenv('TE_FL_STRICT', strict)
+    monkeypatch.setattr(vendor, 'is_gated_delta_net_available', lambda: True)
+    kernel = Mock(return_value=(torch.zeros(1, 3, 2, 128), None))
+    monkeypatch.setitem(sys.modules, vendor.__package__ + '.gdn_impl', SimpleNamespace(flash_gated_delta_rule=kernel))
+    manager = OpManager()
+    if cached:
+        manager.call('gated_delta_net_forward', *simulated(tensors()))
+    kernel.side_effect = error('injected kernel failure')
+    # The unmodified manager may wrap an exception; it must not return fallback.
+    with pytest.raises((error, RuntimeError), match='injected kernel failure'):
+        manager.call('gated_delta_net_forward', *simulated(tensors()))
+
+
+def reference(q, k, v, g, beta, normalize=False):
+    """Independent recurrence used only as the numerical test oracle."""
+    dtype = q.dtype
+    if normalize:
+        q = q / q.norm(dim=-1, keepdim=True).clamp_min(1e-6)
+        k = k / k.norm(dim=-1, keepdim=True).clamp_min(1e-6)
+    q, k, v, g, beta = [x.float() for x in (q, k, v, g, beta)]
+    state = torch.zeros(q.shape[0], q.shape[2], q.shape[3], v.shape[3], device=q.device)
+    ys = []
+    for t in range(q.shape[1]):
+        state = state * g[:, t].exp()[..., None, None]
+        residual = v[:, t] - (k[:, t, :, :, None] * state).sum(-2)
+        state = state + k[:, t, :, :, None] * (beta[:, t, :, None] * residual)[..., None, :]
+        ys.append((q[:, t, :, :, None] * state).sum(-2) / q.shape[-1] ** 0.5)
+    return torch.stack(ys, dim=1).to(dtype)
+
+
+@pytest.mark.parametrize('dtype', [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize('seq,normalize,noncontiguous', [(64, False, False), (65, False, False), (128, True, False), (64, False, True)])
+def test_real_npu_forward_backward(dtype, seq, normalize, noncontiguous, monkeypatch):
+    import json
+    import torch_npu  # noqa: F401
+
+    assert torch.npu.is_available(), 'Real NPU tests require a healthy device'
+    monkeypatch.setenv('TE_FL_STRICT', '0')
+    torch.manual_seed(42)
+    xs = tensors(seq, dtype)
+    xs[:2] = [torch.nn.functional.normalize(x.float(), dim=-1).to(dtype) for x in xs[:2]]
+    if noncontiguous:
+        xs = [x.transpose(1, 2).contiguous().transpose(1, 2) for x in xs]
+    cpu = [x.detach().clone().requires_grad_() for x in xs]
+    device = os.environ.get('GDN_TEST_DEVICE', 'npu:0')
+    npu = [x.to(device).detach().requires_grad_() for x in xs]
+    manager = OpManager()
+    actual, final = manager.call('gated_delta_net_forward', *npu, use_qk_l2norm=normalize)
+    assert final is None
+    assert manager.get_selected_impl_id('gated_delta_net_forward') == 'vendor.npu.gdn_fwd'
+    expected = reference(*cpu, normalize=normalize)
+    dy = torch.randn_like(expected) * 0.05
+    expected.backward(dy)
+    actual.backward(dy.to(device))
+    torch.npu.synchronize()
+    for name, a, b in [('output', actual, expected)] + [(n, a.grad, b.grad) for n, a, b in zip(('q', 'k', 'v', 'g', 'beta'), npu, cpu)]:
+        assert a is not None and b is not None
+        a, b = a.detach().float().cpu(), b.detach().float().cpu()
+        diff = (a - b).abs()
+        l2 = (a - b).norm() / b.norm().clamp_min(1e-12)
+        atol, rtol, limit = (1e-3, 2e-2, 1e-2) if dtype == torch.bfloat16 else (1e-4, 1e-2, 3e-3)
+        print('GDN_ERROR_METRICS=' + json.dumps(dict(dtype=str(dtype), seq=seq, normalize=normalize, noncontiguous=noncontiguous, tensor=name, relative_l2=l2.item(), max_abs=diff.max().item(), mean_abs=diff.mean().item(), p99_abs=diff.quantile(.99).item(), violations=int((diff > atol + rtol * b.abs()).sum()), atol=atol, rtol=rtol, l2_limit=limit)))
+        assert torch.isfinite(a).all() and l2 < limit
+        torch.testing.assert_close(a, b, atol=atol, rtol=rtol)


### PR DESCRIPTION
# Description

为 TE-FL 的 NPU backend 添加 Gated Delta Net（GDN）算子实现，通过现有 OpManager 注册并调用 FLA-NPU 的 AscendC/Triton GDN 前反向算子，供 Megatron Ascend 插件使用

全部源码改动限定在 `transformer_engine/plugin/core/backends/vendor/npu/`，模型层负责原生回退，NPU backend 负责输入校验、运行时能力检查和内核执行。

## Type of change

- [x] New feature（新增功能）
- [ ] Bug fix
- [ ] Breaking change
- [ ] Infra/Build change
- [ ] Code refactoring
- [ ] Documentation change

## Changes

- 添加 GDN 前反向实现和 AscendC 算子封装，处理调用接口与内核之间的张量布局转换。
- 通过现有 NPU backend 注册 `gated_delta_net_forward`，不引入独立 provider 或私有 OpManager。
- 每次调用检查输入和依赖能力。对有效但不支持的输入或缺失的可选运行时，在内核执行前返回 `NotImplemented`，由调用方决定回退；无效输入和执行错误正常抛出。
- 当前优化路径支持 FP16/BF16 的非空稠密 BSHD 输入，Q/K 与 V 的 head dimension 均为 128，chunk size 为 64，`g` 为 FP32，`beta` 与 Q/K/V 同类型。携带初始状态或请求最终状态时返回 `NotImplemented`。
- 添加注册、能力检查、错误传播及真实 NPU 前反向精度测试。

## Validation

- CPU 合同测试：33 项通过。
- 真实 NPU 测试：8 项通过，覆盖 FP16/BF16、序列长度 64/65/128、归一化及非连续输入。
- 48 条输出与梯度误差记录均满足测试中的 relative L2 和逐元素容差。
- 与配套 Megatron 修改联合测试：缺失运行时后的回退、依赖恢复后的优化调用，以及前反向执行均通过。
- Ascend 910C 上完成 8 rank、100 步训练，退出码 0；全部 rank 均记录到优化 GDN 前向和反向成功返回，跳步及 NaN 迭代数均为 0。
- 配置：Qwen3.5-35B-A3B 的 4 层语言／1 层视觉测试配置，BF16，TP2/PP1/EP4/DP4，MBS16/GBS256，关闭 MTP、重计算和数据 packing，冻结视觉模型及投影。使用共同自定义数据入口，包含兼容处理和 checkpoint 过滤。
- Step 3–100 平均耗时 **2259.62 ms/步**，吞吐 **113.29 samples/s**。本轮未重跑基线，不据此声明加速比例；未采集 Profile，也未验证长期收敛等价。

## Checklist

- [ ] 已阅读并遵守目标仓库的 contributing guidelines（提交前由作者确认）
- [x] 已实现上述声明范围内的功能
- [x] 已为能力限制、回退协议及布局转换添加必要注释
- [ ] 已更新独立使用文档（本次未新增）
- [ ] 已确认没有新增 warnings（本轮未完成独立对照核查）
- [x] 已添加并运行与本功能相关的测试
- [ ] 全仓新增及既有测试均通过（本轮仅运行相关测试，未运行全仓测试）
