### PR TITLE
fix(npu): add compatibility workaround for Grouped GEMM checkpoint saving

### DIFF
--- a/transformer_engine/pytorch/tensor/grouped_tensor.py
+++ b/transformer_engine/pytorch/tensor/grouped_tensor.py
@@ -174,6 +174,12 @@ class GroupedTensor(GroupedTensorStorage, torch.Tensor):
         )
         return instance
 
+    # NPU patch: GroupedTensor is a storage-less wrapper. Its real payload is
+    # held by rowwise_data/columnwise_data, so the wrapper has no data pointer.
+    def data_ptr(self) -> int:
+        """Return the null pointer expected for a storage-less tensor wrapper."""
+        return 0
+
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs=None):
         """Dispatch by dequantizing grouped members, then requantizing writes."""


### PR DESCRIPTION
# 描述

本 PR 针对 NPU 环境下 GroupedTensor 保存 checkpoint 时出现的兼容性问题增加上层兼容处理。

GroupedTensor 是一个包装 Tensor，本身不持有独立 Storage，真实数据保存在内部 Tensor 中，同时 GroupedTensor 负责维护分组相关的元数据。

当前 `torch_npu` 在 checkpoint 序列化过程中会将 GroupedTensor 包装层按照普通 NPU Tensor 处理，并尝试查询其底层数据地址。由于 GroupedTensor 本身没有独立 Storage，该流程会触发异常，导致启用 GroupedGEMM / single grouped weight 后无法正常保存 checkpoint。

本 PR 在 GroupedTensor 上层增加兼容处理，使包装 Tensor 不再暴露普通 Tensor 的实际数据地址，从而避免 `torch_npu` 在 checkpoint 序列化过程中错误查询 GroupedTensor 包装层的数据地址，并保证 checkpoint 可以正常保存。

## 修改类型

* [ ] 文档修改
* [x] Bug 修复
* [ ] 新功能
* [ ] 破坏性修改
* [ ] 基础设施 / 构建修改
* [ ] 代码重构

## 修改内容

本 PR 主要包含以下修改：

* 针对无独立 Storage 的 GroupedTensor 增加兼容处理。
* 避免 checkpoint 序列化过程中 `torch_npu` 将 GroupedTensor 包装层作为普通 NPU Tensor 查询实际数据地址。
* 保持 GroupedTensor 内部真实 Tensor 数据以及分组元数据的现有组织方式不变。
* 不修改 GroupedGEMM 的计算语义和执行路径。
* 修复启用 GroupedGEMM / single grouped weight 后 checkpoint 保存失败的问题。
* 验证训练能够正常完成，并成功保存 checkpoint。

## 风险与影响范围

本次问题首先在 NPU 环境下暴露，但当前兼容处理是直接作用于 GroupedTensor 包装层，而不是在 `torch_npu` 或 NPU backend 内增加平台特定判断。

因此，该修改会对所有平台上的 GroupedTensor 生效，包括 CUDA、NPU 以及其他可能使用该包装 Tensor 的后端，而不仅限于 NPU。

修改后的 GroupedTensor 在被查询数据地址时，将按照“wrapper Tensor 本身不持有独立 Storage”的语义处理，而不会暴露内部真实 Tensor 的数据地址。

这意味着本次修改存在以下潜在影响：

* 其他平台中如果存在依赖 `GroupedTensor.data_ptr()` 获取实际数据地址的代码路径，其行为可能发生变化。
* 当前修改依赖 GroupedTensor 作为无独立 Storage 的 wrapper Tensor 这一设计语义成立。
* 内部真实数据 Tensor 本身不受影响，其 Storage、数据地址以及 GroupedGEMM 计算路径均保持不变。
* 当前已验证 NPU 训练和 checkpoint 保存流程，但由于修改对所有平台生效，仍需要关注 CUDA 等其他后端相关测试结果。

因此，本 PR 本质上是一个由 NPU checkpoint 兼容问题触发的 GroupedTensor 上层兼容修复，其影响范围大于单独的 NPU backend 修改。

# 检查项

* [x] 我已阅读并遵循贡献指南
* [x] 功能已经完整实现
* [x] 我已对较难理解的代码添加必要注释
* [ ] 我已同步修改相关文档
* [x] 本次修改没有引入新的警告
* [x] 我已添加测试或训练验证以证明修复有效
* [x] 训练能够正常完成并成功保存 checkpoint
